### PR TITLE
create _site folder in gh action

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Static content copy
         run: |
+          mkdir ./_site
           cp -r ./guidelines ./_site/guidelines
 
       - name: Eleventy Build how-to pages


### PR DESCRIPTION
@jspellman's PR #31 is failing because GH Actions is looking for the `_site` folder.

I added the line to create the folder in the `gh-pages-deploy.yml` file.

@WilcoFiers @iadawn, not sure what you are trying to do here but this will fix the build from failing.

Let me know if I can help.