### PR TITLE
Fixing missing p tag opening bracket

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -530,7 +530,7 @@
 				<section class="guideline"  data-status="exploratory">
 					<h4>Distinguishable relationships</h4>
 					<p class="guideline-text">Meaningful associations between distinct pieces of content are programmatically determinable.</p>
-					p class="ednote">Needs <a href="#additional_research">additional research</a></p>
+					<p class="ednote">Needs <a href="#additional_research">additional research</a></p>
 				</section>
 				<section class="guideline"  data-status="exploratory">
 					<h4>Distinguishable sections</h4>


### PR DESCRIPTION
One of the "needs addition research" editor notes was missing the opening bracket on the p tag.