### PR TITLE
Fix grammatical issues in guidelines/index.html

### DIFF
--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -487,10 +487,10 @@
 					<section class="requirement" data-status="developing" data-requirement-type="foundational">
 						<h5>User-agent default indicator</h5>
 						<div class="body-wrapper">
-							<p class="requirement-text">Focusable item uses the user agent default indicator.</p>
+							<p class="requirement-text">Focusable item uses the user-agent default indicator.</p>
 							<aside class="doclinks">
 								<p><a href="https://w3c.github.io/wcag3/how-to/focus-appearance/user-agent-default-indicator/">
-									<svg aria-hidden="true" class="i-info"><use xlink:href="img/icons.svg#i-info"></use></svg> User agent default indicator methods</a></p>
+									<svg aria-hidden="true" class="i-info"><use xlink:href="img/icons.svg#i-info"></use></svg> User-agent default indicator methods</a></p>
 							</aside>
 						</div>
 					</section>
@@ -790,21 +790,21 @@
 					<p class="guideline-text">Users do not experience physical harm from <a>content</a>.</p>
 					<section class="requirement" data-status="exploratory">
 						<h5>Audio shifting</h4>
-						<p class="requirement-text">Audio shifting designed to create a perception of motion is avoided; or can be paused or prevented.</p>
+						<p class="requirement-text">Audio shifting designed to create a perception of motion is avoided, or can be paused or prevented.</p>
 						<p class="ednote">Needs <a href="#additional_research">additional research</a></p>
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>Flashing</h4>
-						<p class="requirement-text">Flashing or strobing beyond thresholds defined by safety standards are avoided; or can be paused or prevented.</p>
+						<p class="requirement-text">Flashing or strobing beyond thresholds defined by safety standards are avoided, or can be paused or prevented.</p>
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>Motion</h4>
-						<p class="requirement-text">Visual motion and pseudo-motion that lasts longer than 5 seconds is avoided; or can be paused or prevented.</p>
+						<p class="requirement-text">Visual motion and pseudo-motion that lasts longer than 5 seconds is avoided, or can be paused or prevented.</p>
 						<p class="ednote">Needs <a href="#additional_research">additional research</a></p>
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>Motion from interaction</h4>
-						<p class="requirement-text">Visual motion and pseudo-motion triggered by interaction is avoided; or can be prevented, unless the animation is essential to the functionality or the information being conveyed.</p>
+						<p class="requirement-text">Visual motion and pseudo-motion triggered by interaction is avoided or can be prevented, unless the animation is essential to the functionality or the information being conveyed.</p>
 						<p class="ednote">Needs <a href="#additional_research">additional research</a></p>
 					</section>
 				</section>
@@ -866,12 +866,12 @@
 						<p class="ednote">Needs <a href="#additional_research">additional research</a></p>
 					</section>
 					<section class="requirement" data-status="exploratory">
-						<h5>Multistep process</h5>
-						<p class="requirement-text"> Provides context that orients the user in a site or multi-step process.</p>
+						<h5>Multi-step process</h5>
+						<p class="requirement-text">Context is provided to orient the user in a site or multi-step process.</p>
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>Contextual information</h5>
-						<p class="requirement-text"> Provide contextual information to help the user orient within the <a>product</a>.</p>
+						<p class="requirement-text">Contextual information is provided to help the user orient within the <a>product</a>.</p>
 					</section>
 				</section>
 
@@ -945,7 +945,7 @@
 					<p class="guideline-text">Users can complete tasks without needing to memorize nor complete advanced cognitive tasks.</p>
 					<section class="requirement" data-status="exploratory">
 						<h5>Allow automated entry</h5>
-						<p class="requirement-text">Automated input from user agents, 3rd party tools, or copy-and-paste is not prevented.</p>
+						<p class="requirement-text">Automated input from user agents, third-party tools, or copy-and-paste is not prevented.</p>
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>No cognitive tests</h5>
@@ -963,15 +963,15 @@
 					<p class="guideline-text">Users have enough time to read and use <a>content</a>.</p>			
 					<section class="requirement" data-status="exploratory">
 						<h5>Adjust timing at start</h5>
-						<p class="requirement-text">For each process with a time-limit, a mechanism exists to disable or extend the limit before the time-limit starts.</p>
+						<p class="requirement-text">For each process with a time limit, a mechanism exists to disable or extend the limit before the time limit starts.</p>
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>Adjust timing at timeout</h5>
-						<p class="requirement-text">For each process with a time-limit, a mechanism exists to disable or extend the time-limit at timeout.</p>
+						<p class="requirement-text">For each process with a time limit, a mechanism exists to disable or extend the time limit at timeout.</p>
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>Disable timeout</h5>
-						<p class="requirement-text">For each process with a time-limit, a mechanism exists to disable the limit.</p>
+						<p class="requirement-text">For each process with a time limit, a mechanism exists to disable the limit.</p>
 					</section>
 				</section>
 
@@ -1022,7 +1022,7 @@
 					<p class="guideline-text">Users do not have to reenter information or redo work.</p>	
 					<section class="requirement" data-status="exploratory">
 						<h5>Go back in process</h5>
-						<p class="requirement-text">In a multistep process, the interface supports stepping backwards in a process and returning to the current point without data loss.</p>
+						<p class="requirement-text">In a multi-step process, the interface supports stepping backwards in a process and returning to the current point without data loss.</p>
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>Redundant entry</h5>
@@ -1051,7 +1051,7 @@
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>Steps and instructions</h5>
-						<p class="requirement-text">The steps and instructions needed to complete a multistep process are available </p>
+						<p class="requirement-text">The steps and instructions needed to complete a multi-step process are available </p>
 					</section>
 				</section>
 			</section>
@@ -1067,8 +1067,8 @@
 						<p class="ednote">Needs <a href="#additional_research">additional research</a></p>
 					</section>
 					<section class="requirement" data-status="exploratory">
-						<h5>Indicate 3rd party content</h5>
-						<p class="requirement-text">Third party <a>content</a> (AI, Advertising, etc.) is visually and <a>programmatically</a> indicated. </p>
+						<h5>Indicate third-party content</h5>
+						<p class="requirement-text">Third-party <a>content</a> (AI, Advertising, etc.) is visually and <a>programmatically</a> indicated. </p>
 						<p class="ednote">Needs <a href="#additional_research">additional research</a></p>
 					</section>
 					<section class="requirement" data-status="exploratory">
@@ -1366,17 +1366,17 @@
 			<section id="accessibility-supported">
 				<h3>Only accessibility-supported ways of using technologies</h3>
 	
-				<p>The concept of "accessibility-supported" is to account for the variety of user-agents and scenarios. How does an author know that a particular technique for meeting a guideline will work in practice with user-agents that are used by real people?</p>
+				<p>The concept of "accessibility-supported" is to account for the variety of user agents and scenarios. How does an author know that a particular technique for meeting a guideline will work in practice with user agents that are used by real people?</p>
 	
-				<p>The intent is for the responsibility of testing with user-agents to vary depending on the level of conformance.</p> 
+				<p>The intent is for the responsibility of testing with user agents to vary depending on the level of conformance.</p> 
 	
-				<p>At the foundational level of conformance assumptions can be made by authors that methods and techniques provided by WCAG 3.0 work. At higher levels of conformance the author may need to test that a technique works, or check that available user-agents meet the requirement, or a combination of both.</p>
+				<p>At the foundational level of conformance assumptions can be made by authors that methods and techniques provided by WCAG 3.0 work. At higher levels of conformance the author may need to test that a technique works, or check that available user agents meet the requirement, or a combination of both.</p>
 	
-				<p>This approach means the Working Group will ensure that methods and techniques included do have reasonably wide and international support from user-agents, and there are sufficient techniques to meet each requirement.</p>
+				<p>This approach means the Working Group will ensure that methods and techniques included do have reasonably wide and international support from user agents, and there are sufficient techniques to meet each requirement.</p>
 	
-				<p>The intent is that WCAG 3.0 will use a content-management-system to support tagging of methods/techniques with support information. There should also be a process where interested parties can provide information.</p>
+				<p>The intent is that WCAG 3.0 will use a content management system to support tagging of methods/techniques with support information. There should also be a process where interested parties can provide information.</p>
 	
-				<p>An "accessibility support set" is used at higher levels of conformance to define which user-agents and assistive technologies you test with. It would be included in a conformance claim, and enables authors to use techniques that are not provided with WCAG 3.0.</p>
+				<p>An "accessibility support set" is used at higher levels of conformance to define which user agents and assistive technologies you test with. It would be included in a conformance claim, and enables authors to use techniques that are not provided with WCAG 3.0.</p>
 	
 				<p>An exception for long-present bugs in assistive technology is still under discussion.</p>
 	
@@ -1384,7 +1384,7 @@
 
 			<section data-status="exploratory">
 				<h3>Defining conformance scope</h3>
-				<p>When evaluating the accessibility of <a>content</a>, WCAG 3.0 requires the guidelines apply to a specific scope. While the scope can be an all content within a digital <a>product</a>, it is usually one or more sub-sets of the whole. Reasons for this include:</p>
+				<p>When evaluating the accessibility of <a>content</a>, WCAG 3.0 requires the guidelines apply to a specific scope. While the scope can be an all content within a digital <a>product</a>, it is usually one or more subsets of the whole. Reasons for this include:</p>
 				<ul>
 					<li>Large amounts of content are impractical to evaluate comprehensively using anything beyond <a>automated evaluation</a> of items;</li>
 					<li>In many cases, content changes frequently, causing evaluation to be accurate only for a specific moment in time;</li>
@@ -1412,7 +1412,7 @@
 					</div>
 				</dd>
 				<dt data-status="developing"><dfn data-lt="Accessibility support set">Accessibility support set</dfn></dt>
-				<dd><p>The group of user-agents and assistive technologies you test with.</p>
+				<dd><p>The group of user agents and assistive technologies you test with.</p>
 				<div class="ednote">
 					<p>The AG is considering defining a default set of user agents and assistive technologies that they use when validating guidelines. Accessibility support sets may vary based on language, region, or situation. If you are not using the default accessibility set, the conformance report should indicate what set is being used. </p>
 				</div>
@@ -1421,7 +1421,7 @@
 				<dd><p>A formal claim of fact, attributed to a person or organization. An attributable and documented statement of fact regarding procedures practiced in the development and maintenance of the <a>content</a> or <a>product</a> to improve accessibility.</p></dd>
 				<dt><dfn data-lt="Automated|Automatically evaluated|Automated testing|Automatically tested">Automated
 						evaluation</dfn></dt>
-				<dd><p>Evaluation conducted using software tools, typically evaluating code-level features and applying
+				<dd><p><a>Evaluation</a> conducted using software tools, typically evaluating code-level features and applying
 						heuristics for other tests.</p>
 					<p>Automated testing is contrasted with other types of testing that involve human judgement or
 						experience. [=Semi-automated evaluation=] allows machines to guide humans
@@ -1464,7 +1464,7 @@
 				<dt><dfn>Evaluation</dfn></dt>
 				<dd>
 					<p>The process of examining <a>content</a> for <a>conformance</a> to these	guidelines.</p>
-					<p>Different approaches to evaluation include automated <a>evaluation</a>,	<a>semi-automated evaluation</a>, <a>human evaluation</a>, and <a>user testing</a>.</p>
+					<p>Different approaches to evaluation include <a>automated evaluation</a>,	<a>semi-automated evaluation</a>, <a>human evaluation</a>, and <a>user testing</a>.</p>
 				</dd>
 				<dt data-status="developing"><dfn data-lt="Functional needs">Functional need</dfn></dt>
 				<dd>
@@ -1477,7 +1477,7 @@
 				</dd>
 				<dt><dfn data-lt="Human testing|Human evaluated|Human tested|Manual|Manual evaluation|Manual testing|Manually tested">Human evaluation</dfn></dt>
 				<dd>
-					<p>Evaluation conducted by a human, typically to apply human judgement to tests that cannot be fully <a>automatically evaluated</a>.</p>
+					<p><a>Evaluation</a> conducted by a human, typically to apply human judgement to tests that cannot be fully <a>automatically evaluated</a>.</p>
 					<p>Human evaluation is contrasted with <a>automated evaluation</a> which is done entirely by machine, though it includes <a>semi-automated evaluation</a> which allows machines to guide humans to areas that need inspection. Human evaluation involves inspection of content features, by contrast with <a>user testing</a> which directly tests the experience of users with <a>content</a>.</p>
 				</dd>
 				<dt><dfn>Image</dfn></dt>
@@ -1520,7 +1520,24 @@
 				<dt><dfn>Non-literal text</dfn></dt>
 				<dd>
 					<p>Non-literal text uses words or phrases in a way that goes beyond their standard or dictionary meaning to express deeper, more complex ideas. This is also called figurative language. To understand it, users have to interpret the implied meaning behind the words, rather than just their literal or direct meaning.</p>
-					<p>Examples: Allusions, hyperbole, idioms, irony, jokes, litotes, metaphors, metonymies, onomatopoeias, oxymorons, personification, puns, sarcasm, and similes. More detailed examples are available in the <a>Methods</a> section.</p>
+					<p>Examples:</p>
+					<ul>
+						<li>Allusions</li>
+						<li>hyperbole</li>
+						<li>idioms</li>
+						<li>irony</li>
+						<li>jokes</li>
+						<li>litotes</li>
+						<li>metaphors</li>
+						<li>metonymies</li>
+						<li>onomatopoeias</li>
+						<li>oxymorons</li>
+						<li>personification</li>
+						<li>puns</li>
+						<li>sarcasm</li>
+						<li>similes</li>
+					</ul>
+					<p>More detailed examples are available in the <a>Methods</a> section.</p>
 				</dd>
 				<dt data-status="developing"><dfn>Normative</dfn></dt>
 				<dd>
@@ -1538,11 +1555,11 @@
 				</dd>
 				<dt><dfn data-lt="Processes">Process</dfn></dt>
 				<dd>
-					<p>A sequence of steps that need to be completed to accomplish an activity / task from end-to-end.</p>
+					<p>A sequence of steps that need to be completed to accomplish an activity or task from beginning to end.</p>
 				</dd>
 				<dt data-status="developing"><dfn>Product</dfn></dt>
 				<dd>
-					<p>Testing scope that  is a combination of all <a>items</a>, <a>views</a>, and <a>task flows</a> that comprise the web site, set of web pages, web app, etc.</p>
+					<p>Testing scope that  is a combination of all <a>items</a>, <a>views</a>, and <a>task flows</a> that compose the web site, set of web pages, web app, etc.</p>
 				</dd>
 				<dt><dfn data-lt="Programmatically|Programmatically indicated|Programmatically detectable|Programmatically associated">Programmatically determinable</dfn></dt>
 				<dd>
@@ -1556,7 +1573,7 @@
 				</dd>
 				<dt><dfn>Semi-automated evaluation</dfn></dt>
 				<dd>
-					<p>Evaluation conducted using machines to guide humans to areas that need inspection.</p>
+					<p><a>Evaluation</a> conducted using machines to guide humans to areas that need inspection.</p>
 					<p>Semi-automated evaluation involves components of <a>automated evaluation</a> and <a>human evaluation</a>.</p>
 				</dd>
 				<dt><dfn>Single pointer input</dfn></dt>
@@ -1591,7 +1608,7 @@
 				</dd>
 				<dt><dfn>User testing</dfn></dt>
 				<dd>
-					<p>Evaluation of <a>content</a> by observation of how users with specific <a>functional needs</a> are able to complete a <a>process</a> and how the content meets the relevant <a>requirements</a>.</p>
+					<p><a>Evaluation</a> of <a>content</a> by observation of how users with specific <a>functional needs</a> are able to complete a <a>process</a> and how the content meets the relevant <a>requirements</a>.</p>
 				</dd>
 				<dt data-status="developing"><dfn>View</dfn></dt>
 				<dd>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1198,7 +1198,7 @@
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>Adjust background</h5>
-						<p class="requirement-text">Patterns, designs or images placed behind text are avoided or can be removed by the user.</p>
+						<p class="requirement-text">Patterns, designs, or images placed behind text are avoided or can be removed by the user.</p>
 					</section>
 					<section class="requirement" data-status="exploratory">
 						<h5>Font size meaning</h5>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -457,9 +457,9 @@
 						<p>For each focusable item:
 							<ol>
 
-								<li>Is the user-agent default focus indicator used?
+								<li>Is the user agent default focus indicator used?
 									<ul>
-										<li>Yes, the <a href="#user-agent-default-indicator">user-agent default indicator</a> is used AND the <em>accessibility support set</em> meets <a href="#custom-indicator">Custom focus indicators</a>. Stop.</li>
+										<li>Yes, the <a href="#user-agent-default-indicator">user agent default indicator</a> is used AND the <em>accessibility support set</em> meets <a href="#custom-indicator">Custom focus indicators</a>. Stop.</li>
 										<li>No, continue.</li>
 									</ul>
 								</li>
@@ -485,12 +485,12 @@
 						</div>
 					</section>
 					<section class="requirement" data-status="developing" data-requirement-type="foundational">
-						<h5>User-agent default indicator</h5>
+						<h5>User agent default indicator</h5>
 						<div class="body-wrapper">
-							<p class="requirement-text">Focusable item uses the user-agent default indicator.</p>
+							<p class="requirement-text">Focusable item uses the user agent default indicator.</p>
 							<aside class="doclinks">
 								<p><a href="https://w3c.github.io/wcag3/how-to/focus-appearance/user-agent-default-indicator/">
-									<svg aria-hidden="true" class="i-info"><use xlink:href="img/icons.svg#i-info"></use></svg> User-agent default indicator methods</a></p>
+									<svg aria-hidden="true" class="i-info"><use xlink:href="img/icons.svg#i-info"></use></svg> User agent default indicator methods</a></p>
 							</aside>
 						</div>
 					</section>
@@ -1559,7 +1559,7 @@
 				</dd>
 				<dt data-status="developing"><dfn>Product</dfn></dt>
 				<dd>
-					<p>Testing scope that  is a combination of all <a>items</a>, <a>views</a>, and <a>task flows</a> that compose the web site, set of web pages, web app, etc.</p>
+					<p>Testing scope that  is a combination of all <a>items</a>, <a>views</a>, and <a>task flows</a> that make up the website, set of web pages, web app, etc.</p>
 				</dd>
 				<dt><dfn data-lt="Programmatically|Programmatically indicated|Programmatically detectable|Programmatically associated">Programmatically determinable</dfn></dt>
 				<dd>

--- a/guidelines/index.html
+++ b/guidelines/index.html
@@ -1370,7 +1370,7 @@
 	
 				<p>The intent is for the responsibility of testing with user agents to vary depending on the level of conformance.</p> 
 	
-				<p>At the foundational level of conformance assumptions can be made by authors that methods and techniques provided by WCAG 3.0 work. At higher levels of conformance the author may need to test that a technique works, or check that available user agents meet the requirement, or a combination of both.</p>
+				<p>At the foundational level of conformance, assumptions can be made by authors that methods and techniques provided by WCAG 3.0 work. At higher levels of conformance the author may need to test that a technique works, or check that available user agents meet the requirement, or a combination of both.</p>
 	
 				<p>This approach means the Working Group will ensure that methods and techniques included do have reasonably wide and international support from user agents, and there are sufficient techniques to meet each requirement.</p>
 	
@@ -1522,7 +1522,7 @@
 					<p>Non-literal text uses words or phrases in a way that goes beyond their standard or dictionary meaning to express deeper, more complex ideas. This is also called figurative language. To understand it, users have to interpret the implied meaning behind the words, rather than just their literal or direct meaning.</p>
 					<p>Examples:</p>
 					<ul>
-						<li>Allusions</li>
+						<li>allusions</li>
 						<li>hyperbole</li>
 						<li>idioms</li>
 						<li>irony</li>


### PR DESCRIPTION
This includes a separate set of fixes from #274; this set includes more significant impacts on wording.

Note that this PR overlooks any spacing / end-of-sentence punctuation issues, as those are addressed in #274.

- Made hyphenation more consistent, in particular hyphenating adjectives and not nouns
  - I hyphenated user agent only in the case of "user-agent default indicator", assuming it is more of a descriptor in this instance
- Changed semicolons to commas under Prevent physical harm, as the semicolons were creating sentence fragments
- Revised phrasing of the 3 requirements under Orientation to use consistent voice
- Fixed Evaluation to link "automated evaluation" instead of linking to itself; added links to Evaluation from the other more specific definitions
- Converted extremely long comma-delimited list under Non-literal text to an unordered list, so as to not fail WCAG 3's Lists requirement
- Rephrased "from end-to-end" in Process definition to "from beginning to end"
- Corrected "comprise" to "compose" under Product definition

[Preview](https://raw.githack.com/w3c/wcag3/kgf-grammar-fixes/guidelines/index.html)