### PR TITLE
Support :::note and :::example, with numbering scripts from WCAG 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,26 @@ For each item:
 :::
 ```
 
+#### Examples
+
+The following block will be transformed into a yellow "Example" box:
+
+```
+:::example
+Your content here
+:::
+```
+
+#### Notes
+
+The following block will be transformed into a green "Note" box:
+
+```
+:::note
+Your content here
+:::
+```
+
 #### Editor's notes
 
 The following block will be transformed into a green "Editor's Note" box:

--- a/src/components/respec/GuidelinesRespec.astro
+++ b/src/components/respec/GuidelinesRespec.astro
@@ -149,6 +149,59 @@
     });
   }
 
+  const findParentSectionOrDefinition = (el) => el.closest("dd") || el.closest("section");
+
+  /** Numbers notes when there are multiple in one section. */
+  function numberNotes() {
+    // Include :has to skip editor's notes
+    const noteSelector = ".note:has(.note-title span)";
+    const sectionsWithNotes = new Set();
+    document.querySelectorAll(noteSelector).forEach((note) => {
+      sectionsWithNotes.add(findParentSectionOrDefinition(note));
+    });
+
+    sectionsWithNotes.forEach((sec) => {
+      const notes = Array.from(sec.querySelectorAll(noteSelector)).filter(
+        // Only process direct descendants
+        (el) => findParentSectionOrDefinition(el) === sec
+      );
+      // Leave single note alone; 0 notes shouldn't happen based on previous loop
+      if (notes.length < 2) return;
+      // Number multiple notes
+      notes.forEach((note, i) => {
+        const span = note.querySelector(".note-title span");
+        span.textContent = "Note " + (i + 1);
+      });
+    });
+  }
+
+  /**
+   * Changes the numbering of examples to remove number from a lone example in a section,
+   * and restart numbering for multiple in each section.
+   */
+  function renumberExamples() {
+    const sectionsWithExamples = new Set();
+    document.querySelectorAll(".example").forEach((example) => {
+      sectionsWithExamples.add(findParentSectionOrDefinition(example));
+    });
+
+    sectionsWithExamples.forEach((sec) => {
+      const examples = Array.from(sec.querySelectorAll(".example")).filter(
+        // Only process direct descendants
+        (el) => findParentSectionOrDefinition(el) === sec
+      );
+      // No examples shouldn't happen based on previous loop
+      if (!examples.length) return;
+      // Remove numbering on single example, or update numbering on multiple
+      const rmOrAdd = examples.length === 1 ? "rm" : "add";
+      sec.querySelectorAll(".example").forEach((example, i) => {
+        var marker = example.querySelector(".marker");
+        if (rmOrAdd == "rm") marker.textContent = "Example";
+        else marker.textContent = "Example " + (i + 1);
+      });
+    });
+  }
+
   // somewhere along the chain image sizes are being added where I don't want them, doesn't happen locally
   function removeImgSize() {
     document.querySelectorAll("img").forEach(function (node) {
@@ -230,23 +283,6 @@
 
       return returnVal;
     }
-  }
-
-  // scripts before Respec has run
-  function preRespec() {
-    addSummaryMarkers();
-    adjustDfnData();
-  }
-
-  // scripts after Respec has run
-  function postRespec() {
-    adjustNormativity();
-    removeDraftMethodLinks();
-    removeRequirementNum();
-    addRequirementType();
-    addStatusMarkers();
-    removeImgSize();
-    outputJson();
   }
 
   respecConfig = {
@@ -371,8 +407,18 @@
 
     maxTocLevel: 4,
 
-    preProcess: [preRespec],
-    postProcess: [postRespec],
+    preProcess: [addSummaryMarkers, adjustDfnData],
+    postProcess: [
+      adjustNormativity,
+      removeDraftMethodLinks,
+      removeRequirementNum,
+      addRequirementType,
+      addStatusMarkers,
+      numberNotes,
+      renumberExamples,
+      removeImgSize,
+      outputJson,
+    ],
 
     localBiblio: {
       "WCAG3-requirements": {

--- a/src/lib/markdown/guidelines.ts
+++ b/src/lib/markdown/guidelines.ts
@@ -54,10 +54,18 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
           type: "html",
           value: "<summary>Which foundational requirements apply?</summary>",
         });
-      } else if (isTerm && node.name === "ednote") {
+      } else if (node.name === "ednote") {
         const data = node.data || (node.data = {});
         data.hName = "div";
         data.hProperties = { class: "ednote" };
+      } else if (node.name === "example") {
+        const data = node.data || (node.data = {});
+        data.hName = "aside";
+        data.hProperties = { class: "example" };
+      } else if (node.name === "note") {
+        const data = node.data || (node.data = {});
+        data.hName = "div";
+        data.hProperties = { class: "note" };
       }
     } else if (node.type === "textDirective") {
       if (node.name === "term") {


### PR DESCRIPTION
This adds support for Note and Example boxes via Markdown, with the same numbering behavior as in the WCAG 2 Recommendation.

![Screenshot of one note (green box) and one example (yellow box), where the titles do not contain numbers](https://github.com/user-attachments/assets/22087f4f-90fc-43a8-824a-899b65801aea)

![Screenshot of two notes and examples, where the titles do contain numbers](https://github.com/user-attachments/assets/0979d649-20ae-49c6-a67e-3854f3382570)

This also makes the numbering scripts more robust, to not get confused if a section (e.g. a Guideline) and a subsection (e.g. a Requirement) both contain notes or exaamples.

![Screenshot of a note and example each within a Guideline, then another of each within a Requirement under that Guideline, showing that the two behave properly and do not get conflated (no numbering occurs since each is a single instance of its respective type within its immediate parent section).](https://github.com/user-attachments/assets/0a86d2ee-df73-4c1d-845f-8a273b64a4bf)
