### PR TITLE
Add environment variable for skipping early-stage entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ built code is not expected to run properly when this is active!
 
 **Default:** Unset (set to any non-empty value to enable)
 
-### `WCAG_SKIP_RESEARCH`
+### `WCAG_SKIP_WIP`
 
-When set, excludes requirements/assertions that have `needsAdditionalResearch` set to `true`.
+When set, excludes requirements/assertions that have `needsAdditionalResearch` set to `true`,
+or that have `status` set to `placeholder` or `exploratory`.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Each group is defined in a JSON file, with its child guidelines located in a
 subdirectory with the same name.
 
 - Supports [common fields](#common-fields): `children`, `status`
+  - `status` for groups is optional, limited to `developing`, `refining`, `mature`
 - No additional unique fields
 
 #### Guidelines
@@ -102,6 +103,7 @@ listed under. Each guideline is defined in a Markdown file, with its child
 requirements/assertions located in a subdirectory with the same name.
 
 - Supports [common fields](#common-fields): `children`, `howto`, `status`, `title`
+  - `status` for guidelines is optional, limited to `developing`, `refining`, `mature`
 - No additional unique fields
 
 #### Requirements and Assertions
@@ -109,6 +111,7 @@ requirements/assertions located in a subdirectory with the same name.
 Represents each fifth-level heading specifying an individual requirement or assertion.
 
 - Supports [common fields](#common-fields): `howto`, `status`, `title`
+  - `status` for requirements and assertions defaults to `exploratory` if not specified
 - `needsAdditionalResearch` - Optional boolean, indicating whether to
   display a "needs additional research" editor's note
 - `type` - Optional string: `foundational`, `supplemental`, or `assertion`

--- a/README.md
+++ b/README.md
@@ -308,8 +308,12 @@ create a Markdown file under `terms`, then populate its content and any applicab
 
 ### `WCAG_DIFFABLE`
 
-Filters build output to reduce noise when diffing output between changes.
+When set, filters build output to reduce noise when diffing output between changes.
 This is for maintenance purposes only, to catch regressions;
 built code is not expected to run properly when this is active!
 
 **Default:** Unset (set to any non-empty value to enable)
+
+### `WCAG_SKIP_RESEARCH`
+
+When set, excludes requirements/assertions that have `needsAdditionalResearch` set to `true`.

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -5,11 +5,11 @@ import uniq from "lodash-es/uniq";
 /** howto can be set to true to indicate the informative and normative slugs are identical */
 const howtoSchema = z.boolean().or(z.string().regex(/^[\w-]+$/));
 const statusSchema = z.enum(["placeholder", "exploratory", "developing", "refining", "mature"]);
+const parentStatusSchema = statusSchema.exclude(["placeholder", "exploratory"]);
 
 /** Contains fields common between guidelines and requirements */
 const commonChildSchema = z.object({
   howto: howtoSchema.optional(),
-  status: statusSchema.optional(),
   title: z.string().optional(),
 });
 
@@ -43,7 +43,7 @@ export const collections = {
     loader: glob({ pattern: "*.json", base: "./guidelines/groups", ignore: "index.json" }),
     schema: z.object({
       children: childrenSchema,
-      status: statusSchema.optional(),
+      status: parentStatusSchema.optional(),
       title: z.string().optional(),
     }),
   }),
@@ -55,12 +55,14 @@ export const collections = {
       // Moreover, we can't override generateId for requirements to only use slug,
       // due to duplicates across separate guidelines, e.g. "style-guide"
       children: childrenSchema,
+      status: parentStatusSchema.optional(),
     }),
   }),
   requirements: defineCollection({
     loader: glob({ pattern: "*/*/*.md", base: "./guidelines/groups" }),
     schema: commonChildSchema.extend({
       needsAdditionalResearch: z.boolean().optional(),
+      status: statusSchema.default("exploratory"),
       type: z
         .enum([
           "foundational",

--- a/src/lib/guidelines.ts
+++ b/src/lib/guidelines.ts
@@ -3,7 +3,7 @@ import capitalize from "lodash-es/capitalize";
 
 /**
  * Returns a filtered list of requirement/assertion slugs under the given group and guideline,
- * excluding any marked as needing additional research if WCAG_SKIP_RESEARCH is set.
+ * excluding any marked as needing additional research if WCAG_SKIP_WIP is set.
  */
 async function getFilteredRequirements(groupId: string, guidelineSlug: string) {
   const guideline = await getEntry("guidelines", `${groupId}/${guidelineSlug}`);
@@ -16,7 +16,13 @@ async function getFilteredRequirements(groupId: string, guidelineSlug: string) {
       `${groupId}/${guidelineSlug}/${requirementSlug}`
     );
     if (!requirement) throw new Error(`Unresolvable requirement ID: ${requirementSlug}`);
-    if (requirement?.data.needsAdditionalResearch && import.meta.env.WCAG_SKIP_RESEARCH) continue;
+    if (
+      import.meta.env.WCAG_SKIP_WIP &&
+      (requirement.data.needsAdditionalResearch ||
+        requirement.data.status === "placeholder" ||
+        requirement.data.status === "exploratory")
+    )
+      continue;
     filteredRequirements.push(requirementSlug);
   }
   return filteredRequirements;

--- a/src/lib/guidelines.ts
+++ b/src/lib/guidelines.ts
@@ -6,17 +6,56 @@ let groups: Record<string, CollectionEntry<"groups">> = {};
 let guidelines: Record<string, CollectionEntry<"guidelines">> = {};
 let requirements: Record<string, CollectionEntry<"requirements">> = {};
 
+/**
+ * Returns a filtered list of guideline slugs under the given group, excluding any that would
+ * become empty upon filtering the guideline's children based on environment variables.
+ */
+async function getFilteredGuidelines(groupId: string) {
+  const group = await getEntry("groups", groupId);
+  if (!group) throw new Error(`Unresolvable group ID: ${groupId}`);
+
+  const filteredSlugs: string[] = [];
+  for (const guidelineSlug of group.data.children) {
+    const requirements = await getFilteredRequirements(groupId, guidelineSlug);
+    if (requirements.length) filteredSlugs.push(guidelineSlug);
+  }
+  return filteredSlugs;
+}
+
+/**
+ * Returns a filtered list of requirement/assertion slugs under the given group and guideline,
+ * excluding any marked as needing additional research if WCAG_SKIP_RESEARCH is set.
+ */
+async function getFilteredRequirements(groupId: string, guidelineSlug: string) {
+  const guideline = await getEntry("guidelines", `${groupId}/${guidelineSlug}`);
+  if (!guideline) throw new Error(`Unresolvable guideline ID: ${guidelineSlug}`);
+
+  const filteredRequirements: string[] = [];
+  for (const requirementSlug of guideline.data.children) {
+    const requirement = await getEntry(
+      "requirements",
+      `${groupId}/${guidelineSlug}/${requirementSlug}`
+    );
+    if (!requirement) throw new Error(`Unresolvable requirement ID: ${requirementSlug}`);
+    if (requirement?.data.needsAdditionalResearch && import.meta.env.WCAG_SKIP_RESEARCH) continue;
+    filteredRequirements.push(requirementSlug);
+  }
+  return filteredRequirements;
+}
+
 export async function buildGuidelinesHierarchy() {
   // Cache collated collection data for subsequent calls
   if (!Object.keys(groups).length) {
     for (const groupId of groupIds) {
       const group = await getEntry("groups", groupId);
       if (!group) throw new Error(`Unresolvable group ID: ${groupId}`);
+      group.data.children = await getFilteredGuidelines(groupId);
       groups[group.id] = group;
 
       for (const guidelineSlug of group.data.children) {
         const guideline = await getEntry("guidelines", `${groupId}/${guidelineSlug}`);
         if (!guideline) throw new Error(`Unresolvable guideline ID: ${guidelineSlug}`);
+        guideline.data.children = await getFilteredRequirements(groupId, guidelineSlug);
         guidelines[guideline.id] = guideline;
 
         for (const requirementSlug of guideline.data.children) {


### PR DESCRIPTION
This implements an environment variable, `WCAG_SKIP_WIP`, which may be set to skip rendering of requirements that contain `needsAdditionalResearch: true`, `status: placeholder`, or `status: exploratory` in their frontmatter.

Worth noting:

- This does not alter decision trees; it is assumed they do not link to requirements that need additional research
- This does not remove parent guidelines or groups that would end up with no children due to filtering

[Preview](https://gist.githack.com/kfranqueiro/d45b17041dc334cfbd74ae2f6529e6bd/raw/wcag3-filtered.html)