### PR TITLE
Update Astro config to make remark-definition-list plugin work

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,25 @@ Represents each `dt`/`dd` pair appearing in the Glossary section.
 
 **Note:** If a term file is empty, a "to be defined" Editor's Note will be inserted.
 
+### Additional Markdown features
+
+#### Definition lists
+
+Definition lists can be specified directly in Markdown via the following format:
+
+```
+Term
+:   Definition
+
+Another term
+:   Another definition
+
+Shared term
+Another shared term
+:   Shared definition
+:   Another shared definition
+```
+
 ### Custom directives for guidelines Markdown
 
 For more concrete examples, search for these directives in the repository.

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -4,7 +4,7 @@ import node from "@astrojs/node";
 // when https://github.com/withastro/astro/issues/12689 is resolved
 import { load } from "cheerio";
 import fg from "fast-glob";
-import remarkDefinitionList from "remark-definition-list";
+import { remarkDefinitionList, defListHastHandlers } from "remark-definition-list";
 import remarkDirective from "remark-directive";
 
 import { readFile, writeFile } from "fs/promises";
@@ -26,6 +26,10 @@ export default defineConfig({
   markdown: {
     remarkPlugins: [remarkDirective, remarkDefinitionList, ...guidelinesRemarkPlugins],
     rehypePlugins: [...guidelinesRehypePlugins],
+    remarkRehype: {
+      // https://github.com/wataru-chocola/remark-definition-list/issues/50#issuecomment-1445130314
+      handlers: { ...defListHastHandlers }
+    }
   },
   experimental: {
     contentIntellisense: true,


### PR DESCRIPTION
I noticed this wasn't actually working while testing applying it to #318, and verified it does work with this change, which I fortunately found documented in a related issue in the plugin's repository (linked where the change is included).

This also includes a section in the README to document the format, since it's an uncommon Markdown extension.