### PR TITLE
replace incorrect company URL

### DIFF
--- a/src/components/respec/GuidelinesRespec.astro
+++ b/src/components/respec/GuidelinesRespec.astro
@@ -354,7 +354,7 @@
         name: "Francis Storr",
         mailto: "francis.storr@intel.com",
         company: "Intel Corporation",
-        companyURI: "https://tetralogical.com/",
+        companyURI: "https://intel.com/",
         w3cid: 90883,
       },
     ],


### PR DESCRIPTION
replace tetralogical.com with intel.com