### PR TITLE
Fix Requirements ReSpec config

### DIFF
--- a/src/components/respec/RequirementsRespec.astro
+++ b/src/components/respec/RequirementsRespec.astro
@@ -98,7 +98,5 @@
     github: "w3c/wcag3",
 
     maxTocLevel: 4,
-
-    localBiblio: biblio,
   };
 </script>


### PR DESCRIPTION
This resolves the issue that prevented spec-generator from running successfully since #308 was merged.

That PR uncommented a previously-commented line in the Requirements document's `respecConfig` which references a `biblio` variable that doesn't exist. This prevented the ReSpec process from running at all, since `respecConfig` is never successfully defined due to the error.

As far as I can tell, the Requirements document makes no references and needs no `localBiblio`.