### PR TITLE
Improve wrapper handling for how-to links

### DIFF
--- a/src/components/guidelines/EntryText.astro
+++ b/src/components/guidelines/EntryText.astro
@@ -1,5 +1,5 @@
 ---
-import { render, z, type CollectionEntry } from "astro:content";
+import { type CollectionEntry } from "astro:content";
 
 import { computeTitle } from "@/lib/guidelines";
 import { getEntry } from "astro:content";

--- a/src/components/guidelines/EntryText.astro
+++ b/src/components/guidelines/EntryText.astro
@@ -3,6 +3,7 @@ import { render, z, type CollectionEntry } from "astro:content";
 
 import { computeTitle } from "@/lib/guidelines";
 import { getEntry } from "astro:content";
+import { load } from "cheerio";
 
 interface Props {
   entry: CollectionEntry<"guidelines"> | CollectionEntry<"requirements">;
@@ -19,25 +20,36 @@ const howtoPath = parentHowto
   ? `${parentHowto === true ? idParts[1] : parentHowto}/${howtoSlug}/`
   : `${howtoSlug}/`;
 const baseUrl = "https://w3c.github.io/wcag3/how-to/";
-const { Content } = await render(entry);
----
 
-{
-  howtoSlug && (
+function processHtml() {
+  const entryHtml = entry.rendered!.html;
+  if (!howtoSlug) return entryHtml;
+
+  const $ = load(entryHtml, null, false);
+  const $wrappableElement = $("p, ul, ol").first();
+  if (!$wrappableElement.length)
+    throw new Error(`${entry.id}: Can't find element to wrap with link to how-tos`);
+  
+  $wrappableElement.wrap(`<div class="body-wrapper"></div>`).after(`
     <aside class="doclinks">
       <p>
-        <a href={`${baseUrl}${howtoPath}`}>
+        <a href="${baseUrl}${howtoPath}">
           <svg aria-hidden="true" class="i-info">
             <use xlink:href="img/icons.svg#i-info" />
-          </svg>{" "}
-          {entry.collection === "guidelines"
-            ? `How to meet ${computeTitle(entry)}`
-            : `${computeTitle(entry)} methods`}
+          </svg>
+          ${
+            entry.collection === "guidelines"
+              ? `How to meet ${computeTitle(entry)}`
+              : `${computeTitle(entry)} methods`
+          }
         </a>
       </p>
     </aside>
-  )
+  `);
+  return $.html();
 }
+---
+
 {
   entry.collection === "requirements" && entry.data.needsAdditionalResearch && (
     <p class="ednote">
@@ -45,4 +57,4 @@ const { Content } = await render(entry);
     </p>
   )
 }
-<Content />
+<Fragment set:html={processHtml()} />

--- a/src/components/guidelines/EntryText.astro
+++ b/src/components/guidelines/EntryText.astro
@@ -1,8 +1,7 @@
 ---
-import { z, type CollectionEntry } from "astro:content";
+import { render, z, type CollectionEntry } from "astro:content";
 
 import { computeTitle } from "@/lib/guidelines";
-import { renderAndValidate } from "@/lib/zod";
 import { getEntry } from "astro:content";
 
 interface Props {
@@ -20,33 +19,23 @@ const howtoPath = parentHowto
   ? `${parentHowto === true ? idParts[1] : parentHowto}/${howtoSlug}/`
   : `${howtoSlug}/`;
 const baseUrl = "https://w3c.github.io/wcag3/how-to/";
-const { Content, remarkPluginFrontmatter } = await renderAndValidate(
-  entry,
-  z.object({
-    description: z.string(),
-  })
-);
+const { Content } = await render(entry);
 ---
 
 {
-  howtoSlug ? (
-    <div class="body-wrapper">
-      <Fragment set:html={remarkPluginFrontmatter.description} />
-      <aside class="doclinks">
-        <p>
-          <a href={`${baseUrl}${howtoPath}`}>
-            <svg aria-hidden="true" class="i-info">
-              <use xlink:href="img/icons.svg#i-info" />
-            </svg>{" "}
-            {entry.collection === "guidelines"
-              ? `How to meet ${computeTitle(entry)}`
-              : `${computeTitle(entry)} methods`}
-          </a>
-        </p>
-      </aside>
-    </div>
-  ) : (
-    <Fragment set:html={remarkPluginFrontmatter.description} />
+  howtoSlug && (
+    <aside class="doclinks">
+      <p>
+        <a href={`${baseUrl}${howtoPath}`}>
+          <svg aria-hidden="true" class="i-info">
+            <use xlink:href="img/icons.svg#i-info" />
+          </svg>{" "}
+          {entry.collection === "guidelines"
+            ? `How to meet ${computeTitle(entry)}`
+            : `${computeTitle(entry)} methods`}
+        </a>
+      </p>
+    </aside>
   )
 }
 {

--- a/src/components/guidelines/EntryText.astro
+++ b/src/components/guidelines/EntryText.astro
@@ -26,10 +26,13 @@ function processHtml() {
   if (!howtoSlug) return entryHtml;
 
   const $ = load(entryHtml, null, false);
-  const $wrappableElement = $("p, ul, ol").first();
+  const $wrappableElement = $("p, ul, ol")
+    // Exclude nested elements (e.g. inside of a Note)
+    .filter((_, el) => !$(el).parent().length)
+    .first();
   if (!$wrappableElement.length)
     throw new Error(`${entry.id}: Can't find element to wrap with link to how-tos`);
-  
+
   $wrappableElement.wrap(`<div class="body-wrapper"></div>`).after(`
     <aside class="doclinks">
       <p>

--- a/src/lib/markdown/guidelines.ts
+++ b/src/lib/markdown/guidelines.ts
@@ -76,33 +76,5 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
   });
 };
 
-/** Extracts leading paragraphs/lists' HTML to a separate value. */
-const extractLeadingContent: RehypePlugin = () => (tree, file) => {
-  if (!isGuidelineFile(file)) return;
-  const contentTags = ["p", "ul", "ol"];
-  const leadingElements: RootContent[] = [];
-  const textClass = `${getGuidelineFileType(file)}-text`;
-
-  for (
-    let child = tree.children[0];
-    child?.type === "text" || (child?.type === "element" && contentTags.includes(child.tagName));
-    tree.children.shift() && (child = tree.children[0])
-  ) {
-    if (child.type === "element") {
-      const existingClass = child.properties.class;
-      if (existingClass) child.properties.class += ` ${textClass}`;
-      else child.properties.class = textClass;
-    }
-    leadingElements.push(child);
-  }
-  if (!leadingElements.length) file.fail("Leading content expected but not found.");
-
-  const html = toHtml(leadingElements, {
-    allowDangerousCharacters: true,
-    allowDangerousHtml: true,
-  });
-  getFrontmatter(file).description = html;
-};
-
 export const guidelinesRemarkPlugins = [addEmptyTermNote, customDirectives];
-export const guidelinesRehypePlugins = [extractLeadingContent];
+export const guidelinesRehypePlugins = [];

--- a/src/lib/markdown/guidelines.ts
+++ b/src/lib/markdown/guidelines.ts
@@ -1,7 +1,5 @@
-import type { RehypePlugin, RemarkPlugin } from "@astrojs/markdown-remark";
-import type { RootContent } from "hast";
+import type { RemarkPlugin } from "@astrojs/markdown-remark";
 
-import { toHtml } from "hast-util-to-html";
 import { visit } from "unist-util-visit";
 import type { VFile } from "vfile";
 

--- a/src/styles/guidelines.css
+++ b/src/styles/guidelines.css
@@ -6,6 +6,7 @@ caption {
 	color: #404040;
 	border: medium solid #d9d9d9;
 	background-color: #F3F3F3;
+	clear: both;
 }
 summary::after {
 	display: inline-block;
@@ -63,6 +64,15 @@ a.internalDFN[title]:hover, .internalDFN[title]:active, a.internalDFN[title]:foc
 	color: #404040;
 }
 
+:is(.guideline, .requirement) > :is(p, ul, ol) {
+	font-size: 110%;
+	margin-top: 0;
+}
+
+.guideline, .requirement {
+	clear: both;
+}
+
 .guideline {
 	margin-left: 4em;
 	position: relative;
@@ -73,10 +83,6 @@ a.internalDFN[title]:hover, .internalDFN[title]:active, a.internalDFN[title]:foc
 	position: relative;
 }
 
-.guideline-text, .requirement-text {
-	font-size: 110%;
-	margin-top: 0;
-}
 .guideline h3, .requirement h4, .requirement h5 {
 	width: 100%;
 	margin-bottom: 0;
@@ -207,14 +213,10 @@ section {
 
 
 @media (min-width: 768px) { 
-	.guideline .body-wrapper {
-		display: grid;
-		grid-template-columns: 2fr 1fr;
+	.guideline .doclinks {
+		float: right;
+		width: 33%;
 	}
-}
-
-.doclinks {
-	margin-left: 0.2em;
 }
 
 .doclinks a {

--- a/src/styles/guidelines.css
+++ b/src/styles/guidelines.css
@@ -6,7 +6,6 @@ caption {
 	color: #404040;
 	border: medium solid #d9d9d9;
 	background-color: #F3F3F3;
-	clear: both;
 }
 summary::after {
 	display: inline-block;
@@ -64,13 +63,9 @@ a.internalDFN[title]:hover, .internalDFN[title]:active, a.internalDFN[title]:foc
 	color: #404040;
 }
 
-:is(.guideline, .requirement) > :is(p, ul, ol) {
+:is(.guideline, .requirement, .body-wrapper) > :is(p, ul, ol) {
 	font-size: 110%;
 	margin-top: 0;
-}
-
-.guideline, .requirement {
-	clear: both;
 }
 
 .guideline {
@@ -213,10 +208,14 @@ section {
 
 
 @media (min-width: 768px) { 
-	.guideline .doclinks {
-		float: right;
-		width: 33%;
+	.guideline .body-wrapper {
+		display: grid;
+		grid-template-columns: 2fr 1fr;
 	}
+}
+
+.doclinks {
+	margin-left: 0.2em;
 }
 
 .doclinks a {


### PR DESCRIPTION
This refactors the handling for how-to links to resolve multiple issues:

- It expected to find at least one leading paragraph or list element, which would throw an error if e.g. a Note comes first
- It would wrap multiple consecutive elements within the `body-wrapper` element, which would produce the wrong layout
- The processing occurs at the time the guideline/requirement's content is resolved, meaning the link would also end up inserted into informative docs in the future without additional work to pry it out
- The identified elements would be split into a separate frontmatter property, requiring cobbling the two together to output the full text, which I thought might be useful down the road but maybe isn't

This PR moves the processing from within a remark plugin, to specifically within the `EntryText` component, using Cheerio which is probably more likely to be readable to more people (since it effectively follows jQuery's API). This does not add any new dependency; Cheerio was already used for an environment variable that makes upgrades easier to diff. (And Cheerio is what's used extensively for the WCAG 2 build system)

In the case of a Note/etc. occurring first, the link is currently moved below the note. Using a contrived, locally-edited example:

![A requirement containing a note before any other prose, with the how-to link box appearing to the right of the prose after the note](https://github.com/user-attachments/assets/2ca2980e-49d0-4e54-bdeb-6b3e167a4a0b)

This PR also restructures a bit of CSS so that we don't need a remark plugin solely for the purpose of adding a class to a bunch of child elements to increase their font size.

Note that this PR leaves a couple of functions unused in `lib/markdown/guidelines.ts`; I expect those to be useful again later (a further-future PR may move them).

FWIW, the diff of `EntryText.astro` might be slightly quieter with whitespace ignored (`?w=1`).