### PR TITLE
Remove `howto: true` in advance of revamped how-to structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ These are available to multiple data types, as specified in each respective sect
 
 - `children` - A list containing every slug found under a parent entry's corresponding subdirectory,
   in the order they are intended to be listed in the document
-- `howto` - Optional boolean or string indicating the presence of a howto page
+- `howto` - *Deprecated* Optional boolean or string indicating the presence of a howto page
   for the given guideline or requirement
   - `true` indicates the slug to reach the howto is consistent with the folder and filename of the current file
   - A string value indicates an exact slug
-  - This is likely to change when the howto documentation is revisited
+  - *This should currently be avoided until the informative documentation is revisited*
 - `status` - Optional string: one of the status indicators outlined in the Explainer (in lowercase)
 - `title` - Optional title of the guideline, requirement, or term
   - If unspecified, this will be derived from the slug,

--- a/guidelines/groups/image-and-media-alternatives/image-alternatives.md
+++ b/guidelines/groups/image-and-media-alternatives/image-alternatives.md
@@ -7,7 +7,6 @@ children:
   - image-type
   - editable-alternatives
   - style-guide
-howto: true
 ---
 
 Users have equivalent alternatives for images.

--- a/guidelines/groups/image-and-media-alternatives/image-alternatives/decorative-image.md
+++ b/guidelines/groups/image-and-media-alternatives/image-alternatives/decorative-image.md
@@ -1,5 +1,4 @@
 ---
-howto: true
 status: developing
 type: foundational
 ---

--- a/guidelines/groups/image-and-media-alternatives/image-alternatives/detectable-image.md
+++ b/guidelines/groups/image-and-media-alternatives/image-alternatives/detectable-image.md
@@ -1,5 +1,4 @@
 ---
-howto: true
 status: developing
 type: foundational
 ---

--- a/guidelines/groups/image-and-media-alternatives/image-alternatives/equivalent-text-alternative.md
+++ b/guidelines/groups/image-and-media-alternatives/image-alternatives/equivalent-text-alternative.md
@@ -1,5 +1,4 @@
 ---
-howto: true
 status: developing
 type: foundational
 ---

--- a/guidelines/groups/interactive-components/keyboard-focus-appearance/custom-indicator.md
+++ b/guidelines/groups/interactive-components/keyboard-focus-appearance/custom-indicator.md
@@ -1,5 +1,4 @@
 ---
-howto: true
 status: developing
 type: foundational
 ---

--- a/guidelines/groups/interactive-components/keyboard-focus-appearance/user-agent-default-indicator.md
+++ b/guidelines/groups/interactive-components/keyboard-focus-appearance/user-agent-default-indicator.md
@@ -1,5 +1,4 @@
 ---
-howto: true
 status: developing
 type: foundational
 ---

--- a/guidelines/groups/text-and-wording/clear-meaning.md
+++ b/guidelines/groups/text-and-wording/clear-meaning.md
@@ -2,7 +2,6 @@
 children:
   - detectable-text
   - unambiguous-text
-howto: true
 status: developing
 ---
 

--- a/guidelines/groups/text-and-wording/clear-meaning/detectable-text.md
+++ b/guidelines/groups/text-and-wording/clear-meaning/detectable-text.md
@@ -1,5 +1,4 @@
 ---
-howto: true
 type: foundational
 ---
 

--- a/guidelines/groups/text-and-wording/clear-meaning/unambiguous-text.md
+++ b/guidelines/groups/text-and-wording/clear-meaning/unambiguous-text.md
@@ -1,5 +1,4 @@
 ---
-howto: true
 type: foundational
 ---
 


### PR DESCRIPTION
This removes occurrences of `howto: true`, and documents that it should be avoided for the time being.

The current `howto` field was an interim solution to keep the existing ED structurally intact when first creating the new build system, which will eventually integrate informative content more directly.