### PR TITLE
Fail loudly in EntryText if Markdown render failed

### DIFF
--- a/src/components/guidelines/EntryText.astro
+++ b/src/components/guidelines/EntryText.astro
@@ -22,7 +22,12 @@ const howtoPath = parentHowto
 const baseUrl = "https://w3c.github.io/wcag3/how-to/";
 
 function processHtml() {
-  const entryHtml = entry.rendered!.html;
+  if (!entry.rendered) {
+    throw new Error(
+      `EntryText: No rendered HTML found for ${entry.id}; check for Markdown parse failures earlier in log`
+    );
+  }
+  const entryHtml = entry.rendered.html;
   if (!howtoSlug) return entryHtml;
 
   const $ = load(entryHtml, null, false);


### PR DESCRIPTION
This addresses something I stumbled into during a prior attempt at implementing part of #334; it should not currently be an issue with any existing plugins, but I might as well prevent any future confusion now.

If Markdown fails to render, Astro seems to continue merrily along in its build process regardless, which results in the `rendered` property of the content entry not existing. This PR updates `EntryText` to fail loudly on-the-spot where Astro's collection processes didn't.