### PR TITLE
Add status to terms schema to surface in document

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -75,6 +75,7 @@ export const collections = {
   terms: defineCollection({
     loader: glob({ pattern: "*.md", base: "./guidelines/terms" }),
     schema: commonChildSchema.omit({ howto: true }).extend({
+      status: statusSchema.optional(),
       synonyms: z.array(z.string()).min(1).optional(),
     }),
   }),


### PR DESCRIPTION
This makes `status` values in frontmatter of `terms` files reflect properly in the document.

IIUC this used to work, but I overlooked one instance of `commonChildSchema` when I refactored `status` out of it in #316.