### PR TITLE
Don't capitalize first letter of glossary term titles

### DIFF
--- a/guidelines/terms/change-of-viewport-within-a-page-view.md
+++ b/guidelines/terms/change-of-viewport-within-a-page-view.md
@@ -1,6 +1,6 @@
 ---
 status: developing
-title: Change of viewport within a page/view
+title: change of viewport within a page/view
 ---
 
 change of content/context that causes the users keyboard navigation point to change where they have the option to move back out of the new content/context

--- a/guidelines/terms/non-interactive-element.md
+++ b/guidelines/terms/non-interactive-element.md
@@ -1,6 +1,6 @@
 ---
 status: developing
-title: Non-interactive element
+title: non-interactive element
 ---
 
 part of the interface that does not respond to user input and does not include sub-parts

--- a/guidelines/terms/non-literal-language.md
+++ b/guidelines/terms/non-literal-language.md
@@ -1,6 +1,6 @@
 ---
 status: developing
-title: Non-literal language
+title: non-literal language
 ---
 
 words or phrases used in a way that are beyond their standard or dictionary meaning to express deeper, more complex ideas

--- a/guidelines/terms/non-web-software.md
+++ b/guidelines/terms/non-web-software.md
@@ -1,6 +1,6 @@
 ---
 status: developing
-title: Non-web software
+title: non-web software
 ---
 
 software that does not qualify as web content

--- a/guidelines/terms/path-based-gesture.md
+++ b/guidelines/terms/path-based-gesture.md
@@ -1,6 +1,6 @@
 ---
 status: developing
-title: Path-based gesture
+title: path-based gesture
 ---
 
 gesture that depends on the path of the pointer input and not just its endpoints

--- a/guidelines/terms/semi-automated-evaluation.md
+++ b/guidelines/terms/semi-automated-evaluation.md
@@ -1,6 +1,6 @@
 ---
 status: developing
-title: Semi-automated evaluation
+title: semi-automated evaluation
 ---
 
 :term[evaluation] conducted using machines to guide humans to areas that need inspection

--- a/guidelines/terms/two-dimensional-content.md
+++ b/guidelines/terms/two-dimensional-content.md
@@ -1,6 +1,6 @@
 ---
 status: exploratory
-title: Two-dimensional content
+title: two-dimensional content
 ---
 
 :::ednote

--- a/src/components/guidelines/EntryText.astro
+++ b/src/components/guidelines/EntryText.astro
@@ -1,9 +1,8 @@
 ---
-import { type CollectionEntry } from "astro:content";
-
-import { computeTitle } from "@/lib/guidelines";
-import { getEntry } from "astro:content";
+import { getEntry, type CollectionEntry } from "astro:content";
 import { load } from "cheerio";
+
+import { computeGuidelineTitle } from "@/lib/guidelines";
 
 interface Props {
   entry: CollectionEntry<"guidelines"> | CollectionEntry<"requirements">;
@@ -47,8 +46,8 @@ function processHtml() {
           </svg>
           ${
             entry.collection === "guidelines"
-              ? `How to meet ${computeTitle(entry)}`
-              : `${computeTitle(entry)} methods`
+              ? `How to meet ${computeGuidelineTitle(entry)}`
+              : `${computeGuidelineTitle(entry)} methods`
           }
         </a>
       </p>

--- a/src/components/guidelines/GlossaryDefinition.astro
+++ b/src/components/guidelines/GlossaryDefinition.astro
@@ -1,7 +1,7 @@
 ---
 import { render, type CollectionEntry } from "astro:content";
 
-import { computeTitle } from "@/lib/guidelines";
+import { computeTermTitle } from "@/lib/guidelines";
 
 interface Props {
   termEntry: CollectionEntry<"terms">;
@@ -13,6 +13,6 @@ const { Content } = await render(termEntry);
 ---
 
 <dt data-status={status}>
-  <dfn data-lt={synonyms ? synonyms.join("|") : undefined}>{computeTitle(termEntry)}</dfn>
+  <dfn data-lt={synonyms ? synonyms.join("|") : undefined}>{computeTermTitle(termEntry)}</dfn>
 </dt>
 <dd><Content /></dd>

--- a/src/components/guidelines/GlossaryDefinitionList.astro
+++ b/src/components/guidelines/GlossaryDefinitionList.astro
@@ -2,10 +2,10 @@
 import { getCollection } from "astro:content";
 import { sortBy } from "lodash-es";
 
+import { computeTermTitle } from "@/lib/guidelines";
 import GlossaryDefinition from "./GlossaryDefinition.astro";
-import { computeTitle } from "@/lib/guidelines";
 
-const entries = sortBy(await getCollection("terms"), (entry) => computeTitle(entry));
+const entries = sortBy(await getCollection("terms"), (entry) => computeTermTitle(entry));
 ---
 
 <dl>

--- a/src/components/guidelines/GlossaryDefinitionList.astro
+++ b/src/components/guidelines/GlossaryDefinitionList.astro
@@ -5,7 +5,9 @@ import { sortBy } from "lodash-es";
 import { computeTermTitle } from "@/lib/guidelines";
 import GlossaryDefinition from "./GlossaryDefinition.astro";
 
-const entries = sortBy(await getCollection("terms"), (entry) => computeTermTitle(entry));
+const entries = sortBy(await getCollection("terms"), (entry) =>
+  computeTermTitle(entry).toLowerCase()
+);
 ---
 
 <dl>

--- a/src/components/guidelines/GroupsList.astro
+++ b/src/components/guidelines/GroupsList.astro
@@ -1,5 +1,5 @@
 ---
-import { buildGuidelinesHierarchy, computeTitle } from "@/lib/guidelines";
+import { buildGuidelinesHierarchy, computeGuidelineTitle } from "@/lib/guidelines";
 
 const groups = await buildGuidelinesHierarchy();
 ---
@@ -8,7 +8,7 @@ const groups = await buildGuidelinesHierarchy();
   {
     groups.map((group) => (
       <li>
-        <a href={`#${group.id}`}>{computeTitle(group)}</a>
+        <a href={`#${group.id}`}>{computeGuidelineTitle(group)}</a>
       </li>
     ))
   }

--- a/src/components/guidelines/Guidelines.astro
+++ b/src/components/guidelines/Guidelines.astro
@@ -1,5 +1,5 @@
 ---
-import { buildGuidelinesHierarchy, computeTitle } from "@/lib/guidelines";
+import { buildGuidelinesHierarchy, computeGuidelineTitle } from "@/lib/guidelines";
 
 import EntryText from "./EntryText.astro";
 
@@ -9,10 +9,10 @@ const groups = await buildGuidelinesHierarchy();
 {
   groups.map((group) => (
     <section data-status={group.data.status || undefined}>
-      <h3>{computeTitle(group)}</h3>
+      <h3>{computeGuidelineTitle(group)}</h3>
       {group.data.guidelines.map((guideline) => (
         <section class="guideline" data-status={guideline.data.status || undefined}>
-          <h4>{computeTitle(guideline)}</h4>
+          <h4>{computeGuidelineTitle(guideline)}</h4>
           <EntryText entry={guideline} />
           {guideline.data.requirements.map((requirement) => (
             <section
@@ -21,7 +21,7 @@ const groups = await buildGuidelinesHierarchy();
               data-requirement-type={requirement.data.type}
               data-skip={requirement.skippable}
             >
-              <h5>{computeTitle(requirement)}</h5>
+              <h5>{computeGuidelineTitle(requirement)}</h5>
               <EntryText entry={requirement} />
             </section>
           ))}

--- a/src/lib/guidelines.ts
+++ b/src/lib/guidelines.ts
@@ -103,9 +103,24 @@ export interface EntryWithTitle {
   data: { title?: string };
 }
 
-/** Returns entry title if specified, or falls back to converting from its slug. */
-export function computeTitle(entry: EntryWithTitle) {
+interface ComputeTitleOptions {
+  capitalize: boolean;
+}
+
+function computeTitle(entry: EntryWithTitle, options: ComputeTitleOptions) {
   if (entry.data.title) return entry.data.title;
   const slug = entry.id.replace(/^.*\//, "");
-  return capitalize(slug.replace(/-/g, " "));
+  const title = slug.replace(/-/g, " ");
+  return options.capitalize ? capitalize(title) : title;
 }
+
+/**
+ * Returns group/guideline/requirement/assertion title if specified,
+ * or falls back to converting from its slug.
+ */
+export const computeGuidelineTitle = (entry: EntryWithTitle) =>
+  computeTitle(entry, { capitalize: true });
+
+/** Returns term title if specified, or falls back to converting from its slug. */
+export const computeTermTitle = (entry: CollectionEntry<"terms">) =>
+  computeTitle(entry, { capitalize: false });


### PR DESCRIPTION
This splits the `computeTitle` function used for default title behavior into a common function and 2 exposed functions, one for guidelines (and groups, requirements, and assertions) and the other for terms. The function for terms does not capitalize the first letter. This makes the format of glossary terms more consistent with WCAG 2's glossary.

I've also updated the case in any overridden term titles. (I'll have to take another look when synchronizing the editorial branch.)

@netlify /guidelines/#glossary