### PR TITLE
editorial tweaks to support announcements — index.astro

### DIFF
--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -42,18 +42,11 @@ import GuidelinesRespec from "@/components/respec/GuidelinesRespec.astro";
 					<li>We would like feedback on this draft. You can raise a <a href="https://github.com/w3c/wcag3/issues">GitHub issue</a> or email <a href="mailto:public-agwg-comments@w3.org?subject=WCAG%203.0%20public%20comment">public-agwg-comments@w3.org</a>.</li>					
 				</ul>
 			</details>
-			<h3>What's new in this version of WCAG 3.0?</h3>
+			<h3>About this draft</h3>
 
-			<p>This draft includes an updated list of the potential guidelines, requirements, and assertions that have progressed to <a href="#section-status-levels">developing status</a>.</p> 
+			<p>This draft includes an updated list of the potential guidelines, requirements, and assertions that have progressed to <a href="#section-status-levels">Developing status</a>.</p> 
 			
-			<p>Requirements and assertions at the Exploratory level are not listed in this Working Draft. If you would like to see the complete list, please review the <a href="https://w3c.github.io/wcag3/guidelines/">Editor's Draft</a>. </p>
-
-			<p>The list of requirements is longer than the list of success criteria in WCAG 2. This is because:</p>
-			<ul>
-				<li>the intent at this stage is to be as inclusive as possible of potential requirements, and</li>
-				<li>WCAG 3.0 requirements are more granular than WCAG 2 success criteria. </li>
-			</ul>
-			<p>The final set of requirements in WCAG 3.0 will be different from what is in this draft. Requirements are likely to be added, combined, and removed. We also expect changes to the text of the requirements. Only some of the requirements will be used to meet the base level of conformance.</p>
+			<p>Requirements and assertions at the Exploratory status are not listed in this Working Draft. If you would like to see the complete list, please review the <a href="https://w3c.github.io/wcag3/guidelines/">Editor's Draft</a>. </p>
 
 			<p>Please consider the following questions when reviewing this draft:</p>
 			<ul>
@@ -62,21 +55,22 @@ import GuidelinesRespec from "@/components/respec/GuidelinesRespec.astro";
 				<li>What are your thoughts on assertions?</li>
 				<li>Does the "Which foundational requirements apply?" section in <a href="#image-alternatives">Image Alternatives</a>, <a href="#text-appearance">Text Appearance</a>, or <a href="#keyboard-focus-appearance">Keyboard Focus Appearance</a> help you understand how to use the requirements?</li>
 			</ul>
-			<p>Additionally the Working Group would welcome any research that supports requirements or assertions.</p>
+			<p>Additionally the Working Group welcomes any research that supports requirements or assertions.</p>
 	
-			<p>To provide feedback, please file a <a href="https://github.com/w3c/wcag3/issues">GitHub issue</a> or email <a href="mailto:public-agwg-comments@w3.org?subject=WCAG%203.0%20public%20comment">public-agwg-comments@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-agwg-comments/">comment archive</a>).</p>
+			<p>To provide feedback, please open a new issue in the <a href="https://github.com/w3c/wcag3/issues">wcag3 GitHub repository</a>. Create a separate GitHub issue for each topic, rather than commenting on multiple topics in a single issue. If it's not feasible for you to use GitHub, email your comments to <a href="mailto:public-agwg-comments@w3.org?subject=WCAG%203.0%20public%20comment">public-agwg-comments@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-agwg-comments/">comment archive</a>). Please put your comments in the body of the message, not as an attachment.</p>
 
 			<section>
-				<h3>About WCAG 3.0</h3>
-				<p>This specification presents a new model and guidelines to make web content and applications accessible to people with disabilities. W3C Accessibility Guidelines (WCAG) 3.0 supports a wide set of user needs, uses new approaches to testing, and allows frequent maintenance of guidelines and related content to keep pace with accelerating technology changes. WCAG 3.0 supports this evolution by focusing on the <a>functional needs</a> of users. These needs are then supported by guidelines that are written as outcome statements, requirements, assertions, and technology-specific methods to meet those needs.</p>
-				<p>WCAG 3.0 is a successor to <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines 2.2</a> [[WCAG22]] and previous versions, but does not <a>deprecate</a> WCAG 2. It will also incorporate some content from and partially extend <a href="https://www.w3.org/TR/UAAG20/"> User Agent Accessibility Guidelines 2.0</a> [[UAAG20]] and <a href="https://www.w3.org/TR/ATAG20/"> Authoring Tool Accessibility Guidelines 2.0</a> [[ATAG20]]. These earlier versions provided a flexible model that kept them relevant for over 15 years. However, changing technology and changing needs of people with disabilities have led to the need for a new model to address content accessibility more comprehensively and flexibly.</p>
-				<p>There are many differences between WCAG 2 and WCAG 3.0. The WCAG 3.0 guidelines address the accessibility of web content on desktops, laptops, tablets, mobile devices, wearable devices, and other Web of Things devices. The guidelines apply to various types of web content, including static, dynamic, interactive, and streaming content; visual and auditory media; virtual and augmented reality; and alternative access presentation and control methods. These  guidelines also address related web tools such as user agents (browsers and assistive technologies), content management systems, authoring tools, and testing tools.</p>
-				<p>Each <a>guideline</a> in this standard provides information on accessibility practices that address documented <a>user needs</a> of people with disabilities. Guidelines are supported by multiple <a>requirements</a> to determine whether the need has been met. Guidelines are also supported by technology-specific <a>methods</a> to meet each requirement. </p>
-				<p>Content that conforms to WCAG 2.2 Level A and Level AA is expected to meet most of the minimum conformance level of this new standard but, since WCAG 3.0 includes additional tests and different scoring mechanics, additional work will be needed to reach full conformance. Since the new standard will use a different conformance model, the Accessibility Guidelines Working Group expects that some organizations may wish to continue using WCAG 2, while others may wish to migrate to the new standard. For those that wish to migrate to WCAG 3, the Working Group will provide transition support materials, which may use mapping and other approaches to facilitate migration.</p>
+				<h4>Draft requirements</h4>
+				<p>The list of requirements is longer than the list of success criteria in WCAG 2. This is because:</p>
+					<ul>
+					<li>the intent at this stage is to be as inclusive as possible of potential requirements, and</li>
+					<li>WCAG 3.0 requirements are more granular than WCAG 2 success criteria. </li>
+					</ul>
+				<p>The final set of requirements in WCAG 3.0 will be different from what is in this draft. Requirements are likely to be added, combined, and removed. We also expect changes to the text of the requirements. Only some of the requirements will be used to meet the base level of conformance.</p>
 			</section>
 
 			<section>
-				<h3>Section status levels</h3>
+				<h4>Section status levels</h4>
 				<p>As part of the WCAG 3.0 drafting process, each <a>normative</a> section of this document is given a status. This status is used to indicate how far along in the development this section is, how ready it is for experimental adoption, and what kind of feedback the Accessibility Guidelines Working Group is looking for.</p>
 				<ul>
 					<li><strong id="status-placeholder">Placeholder</strong>: This content is temporary. It showcases the type of content to expect here. All of this is expected to be replaced. No feedback is needed on placeholder content.</li>
@@ -85,6 +79,15 @@ import GuidelinesRespec from "@/components/respec/GuidelinesRespec.astro";
 					<li><strong id="status-refining">Refining</strong>: This content is ready for wide public review and experimental adoption. The working group has reached consensus on this section. Feedback should be focused on the feasibility of implementation.</li>
 					<li><strong id="status-mature">Mature</strong>: This content is believed by the working group to be ready for recommendation. Feedback on this section should be focused on edge-case scenarios that the working group may not have anticipated.</li>
 				</ul>
+			</section>
+			
+			<section>
+				<h3>About WCAG 3.0</h3>
+				<p>This specification presents a new model and guidelines to make web content and applications accessible to people with disabilities. W3C Accessibility Guidelines (WCAG) 3.0 supports a wide set of user needs, uses new approaches to testing, and allows frequent maintenance of guidelines and related content to keep pace with accelerating technology changes. WCAG 3.0 supports this evolution by focusing on the <a>functional needs</a> of users. These needs are then supported by guidelines that are written as outcome statements, requirements, assertions, and technology-specific methods to meet those needs.</p>
+				<p>WCAG 3.0 is a successor to <a href="https://www.w3.org/TR/WCAG22/">Web Content Accessibility Guidelines 2.2</a> [[WCAG22]] and previous versions, but does not <a>deprecate</a> WCAG 2. It will also incorporate some content from and partially extend <a href="https://www.w3.org/TR/UAAG20/"> User Agent Accessibility Guidelines 2.0</a> [[UAAG20]] and <a href="https://www.w3.org/TR/ATAG20/"> Authoring Tool Accessibility Guidelines 2.0</a> [[ATAG20]]. These earlier versions provided a flexible model that kept them relevant for over 15 years. However, changing technology and changing needs of people with disabilities have led to the need for a new model to address content accessibility more comprehensively and flexibly.</p>
+				<p>There are many differences between WCAG 2 and WCAG 3.0. The WCAG 3.0 guidelines address the accessibility of web content on desktops, laptops, tablets, mobile devices, wearable devices, and other Web of Things devices. The guidelines apply to various types of web content, including static, dynamic, interactive, and streaming content; visual and auditory media; virtual and augmented reality; and alternative access presentation and control methods. These  guidelines also address related web tools such as user agents (browsers and assistive technologies), content management systems, authoring tools, and testing tools.</p>
+				<p>Each <a>guideline</a> in this standard provides information on accessibility practices that address documented <a>user needs</a> of people with disabilities. Guidelines are supported by multiple <a>requirements</a> to determine whether the need has been met. Guidelines are also supported by technology-specific <a>methods</a> to meet each requirement. </p>
+				<p>Content that conforms to WCAG 2.2 Level A and Level AA is expected to meet most of the minimum conformance level of this new standard but, since WCAG 3.0 includes additional tests and different scoring mechanics, additional work will be needed to reach full conformance. Since the new standard will use a different conformance model, the Accessibility Guidelines Working Group expects that some organizations may wish to continue using WCAG 2, while others may wish to migrate to the new standard. For those that wish to migrate to WCAG 3, the Working Group will provide transition support materials, which may use mapping and other approaches to facilitate migration.</p>
 			</section>
 
 		</section>


### PR DESCRIPTION
This PR would help us point to the document sections from the announcements (WAI email, WAI Nes, LinkedIn, Mastodon) and not need to provide redundant information in each announcement.

Edit suggestions:
* Two h3 sections: 'About this draft', 'About WCAG 3.0'
* To help reviewers focus on the review questions and ways to comment, move the info about lots of requirements to a section 'Draft requirements'
* Include the 'Section status levels' under 'About this draft" (since it's directly related to the draft and it won't live on after WCAG 3 is done :-)
* Add more details about submitting feedback (which we usually do in announcements, and instead can just point here :)