### PR TITLE
Reorder change log latest-first

### DIFF
--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -208,17 +208,12 @@ import GuidelinesRespec from "@/components/respec/GuidelinesRespec.astro";
 			</p>
 
 			<ul>
-				<li>2021-06-08: Moved explanatory information to <a href="https://www.w3.org/TR/wcag-3.0-explainer/">Explainer for W3C Accessibility Guidelines (WCAG) 3.0</a>
-				</li>
-				<li>2021-12-07: Add Project Manager
-				</li>
-				<li>2023-07-24: Changed approach to WCAG 3.0 based feedback and removed old material that was not consistent with the new approach. Added WCAG 3.0 Guideline placeholders to indicate maturity level.
-				</li>
-				<li>2024-03-15: Updated placeholder guidelines with exploratory guidelines.
-				</li>
-				<li>2024-12-12: Reorganized exploratory guidelines; added 3 developing guidelines and accessibility supported; added user agent support, updated conformance section,  and moved explanatory content to the <a href="https://www.w3.org/TR/wcag-3.0-explainer/">Explainer for WCAG 3.0</a>
-				</li>
 				<li>2025-09-04: Published requirements and assertions that have reached developing; removed exploratory content from draft; and updated assertions section of <a href="https://www.w3.org/TR/wcag-3.0-explainer/">Explainer for WCAG 3.0</a>.</li>
+				<li>2024-12-12: Reorganized exploratory guidelines; added 3 developing guidelines and accessibility supported; added user agent support, updated conformance section,  and moved explanatory content to the <a href="https://www.w3.org/TR/wcag-3.0-explainer/">Explainer for WCAG 3.0</a></li>
+				<li>2024-03-15: Updated placeholder guidelines with exploratory guidelines.</li>
+				<li>2023-07-24: Changed approach to WCAG 3.0 based feedback and removed old material that was not consistent with the new approach. Added WCAG 3.0 Guideline placeholders to indicate maturity level.</li>
+				<li>2021-12-07: Add Project Manager</li>
+				<li>2021-06-08: Moved explanatory information to <a href="https://www.w3.org/TR/wcag-3.0-explainer/">Explainer for W3C Accessibility Guidelines (WCAG) 3.0</a></li>
 			</ul>
 		</section>
 		<section class="appendix">


### PR DESCRIPTION
This resolves something that @shawna-slh flagged in #365, which I had also been wondering about - the change log in this document had been ordered earliest-to-latest, whereas others I'd seen (e.g. in WCAG 2) are latest-to-earliest.

(Kevin asked me to raise an issue; it was easier for me to just open the PR, even if we don't merge it for this publication cycle.)

@netlify /guidelines/#change-log