### PR TITLE
Define optional functionalNeeds field for requirements/assertions

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -64,6 +64,7 @@ export const collections = {
   requirements: defineCollection({
     loader: glob({ pattern: "*/*/*.md", base: "./guidelines/groups" }),
     schema: commonChildSchema.extend({
+      functionalNeeds: z.array(z.string()).optional(),
       needsAdditionalResearch: z.boolean().optional(),
       status: statusSchema.default("exploratory"),
       type: z


### PR DESCRIPTION
This adds an optional `functionalNeeds` field for requirements/assertions, expecting an array of strings.

This can be specified in either of the following ways within frontmatter:

```
functionalNeeds:
  - one
  - two
```

```
functionalNeeds: [one, two]
```

This is mainly a provision for brainstorming; it is not yet used or displayed anywhere.