### PR TITLE
Build: Fail on unrecognized directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "build": "astro build",
+    "build": "astro build --force",
     "check": "astro check",
     "cspell": "cspell .",
     "preview": "astro preview",
     "start": "astro dev",
-    "sync": "astro sync",
+    "sync": "astro sync --force",
     "astro": "astro",
     "postinstall": "patch-package"
   },

--- a/src/lib/markdown/guidelines.ts
+++ b/src/lib/markdown/guidelines.ts
@@ -64,12 +64,12 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
         const data = node.data || (node.data = {});
         data.hName = "div";
         data.hProperties = { class: "note" };
-      }
+      } else file.fail(`Unrecognized container directive :::${node.name}`);
     } else if (node.type === "textDirective") {
       if (node.name === "term") {
         const data = node.data || (node.data = {});
         data.hName = "a";
-      }
+      } else file.fail(`Unrecognized inline directive :${node.name}`);
     }
   });
 };


### PR DESCRIPTION
This will fail Markdown processing if an unrecognized directive is encountered, which should prevent typos like what https://github.com/w3c/wcag3/commit/1fa26b3e51f0f780daf4a2a0711fb489dc5f999c fixed from slipping through.

This also updates the build and sync npm scripts to always clear the content cache before building; without this, Markdown processing errors may not surface on subsequent builds if the file with the problem hasn't changed, which can be confusing.

Example error:
```
[ERROR] [glob-loader] Error rendering image-and-media-alternatives/image-alternatives/equivalent-text-alternative.md: Failed to parse Markdown file "/home/kgf/dev/w3c/wcag3/guidelines/groups/image-and-media-alternatives/image-alternatives/equivalent-text-alternative.md":
Unrecognized inline directive :spell
```