### PR TITLE
Update WCAG 3 requirements

### DIFF
--- a/src/pages/requirements.astro
+++ b/src/pages/requirements.astro
@@ -55,7 +55,7 @@ import RequirementsRespec from "@/components/respec/RequirementsRespec.astro";
 					<li>diverse audience, and</li>
 					<li>identify who benefits.</li>
 				</ul>
-				<p>WCAG 3 does not want to advance the WCAG 2 requirement: &quot;Ensure that the revision is 'backwards and forward compatible'&quot;. The intention is to include WCAG 2 content, but migrate it to a different structure and conformance model. WCAG 3 plans to migrate the content of WCAG 2.2 to WCAG 3.0.</p>
+				<p>WCAG 3 does not want to advance the WCAG 2 requirement: "Ensure that the revision is 'backwards and forward compatible'". The <a href="https://w3c.github.io/wcag/requirements/22/">WCAG 2.2 Requirements</a> are very specific to WCAG 2.2 and will <em>not</em> be advanced by WCAG 3. The intention is to include WCAG 2 content, but migrate it to a different structure and conformance model. WCAG 3 plans to migrate the content of WCAG 2.2 to WCAG 3.</p>
 			</section>
 			<section>
 				<h3>WCAG 3 Scope</h3>


### PR DESCRIPTION
1. Per #206, change most references to 3.0 to 3, and 2.x to 2.
2. Remove reference to WCAG 2.1 Requirements as it’s out of date and there is no 2.2 equivalent.
3. Fix some capitalization

There is more work to do on this as the Silver taskforce was still in existence when it was written and some of the content is a little stale, but this is a start