### PR TITLE
Add user-needs and tests block directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,30 @@ Your content here
 :::
 ```
 
+#### User Needs
+
+The following block will be transformed into a User Needs `details` element,
+with an indication that its content is non-normative.
+This is _only_ valid within guidelines.
+
+```
+:::user-needs
+Your content here
+:::
+```
+
+#### Tests
+
+The following block will be transformed into a Tests `details` element,
+with an indication that its content is non-normative.
+This is _only_ valid within requirements.
+
+```
+:::tests
+Your content here
+:::
+```
+
 #### Glossary Term References
 
 The text inside `:term[...]` will be transformed into a link referencing a term in the glossary,

--- a/src/lib/markdown/guidelines.ts
+++ b/src/lib/markdown/guidelines.ts
@@ -52,6 +52,22 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
           type: "html",
           value: "<summary>Which foundational requirements apply?</summary>",
         });
+      } else if (isGuideline && node.name === "user-needs") {
+        const data = node.data || (node.data = {});
+        data.hName = "details";
+        data.hProperties = { class: "user-needs" };
+        node.children.unshift({
+          type: "html",
+          value: "<summary>User Needs</summary><p><em>This section is non-normative.</em></p>",
+        });
+      } else if (isGuideline && node.name === "tests") {
+        const data = node.data || (node.data = {});
+        data.hName = "details";
+        data.hProperties = { class: "tests" };
+        node.children.unshift({
+          type: "html",
+          value: "<summary>Tests</summary><p><em>This section is non-normative.</em></p>",
+        });
       } else if (node.name === "ednote") {
         const data = node.data || (node.data = {});
         data.hName = "div";

--- a/src/lib/markdown/guidelines.ts
+++ b/src/lib/markdown/guidelines.ts
@@ -53,6 +53,10 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
           value: "<summary>Which foundational requirements apply?</summary>",
         });
       } else if (isGuideline && node.name === "user-needs") {
+        const type = getGuidelineFileType(file);
+        if (type !== "guideline")
+          file.fail(`user-needs expected at guideline level but found at ${type} level`);
+
         const data = node.data || (node.data = {});
         data.hName = "details";
         data.hProperties = { class: "user-needs" };
@@ -61,6 +65,10 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
           value: "<summary>User Needs</summary><p><em>This section is non-normative.</em></p>",
         });
       } else if (isGuideline && node.name === "tests") {
+        const type = getGuidelineFileType(file);
+        if (type !== "requirement")
+          file.fail(`tests expected at requirement level but found at ${type} level`);
+
         const data = node.data || (node.data = {});
         data.hName = "details";
         data.hProperties = { class: "tests" };


### PR DESCRIPTION
This adds support for expandable, non-normative User Needs and Tests sections within the normative document.

User Needs are expected at the guideline level, while Tests are expected at the requirement level; each directive will fail if used at the wrong level.

In the future, this content will likely be migrated to separate informative documentation pages, but those are not fully fleshed out yet.