### PR TITLE
Suppress margin-left on guidelines/requirements for mobile breakpoint

### DIFF
--- a/src/styles/guidelines.css
+++ b/src/styles/guidelines.css
@@ -68,14 +68,16 @@ a.internalDFN[title]:hover, .internalDFN[title]:active, a.internalDFN[title]:foc
 	margin-top: 0;
 }
 
-.guideline {
-	margin-left: 4em;
+.guideline,
+.guideline .requirement {
 	position: relative;
 }
 
-.guideline .requirement {
-	margin-left: 4em;
-	position: relative;
+@media (min-width: 768px) {
+	.guideline,
+	.guideline .requirement {
+		margin-left: 4em;
+	}
 }
 
 .guideline h3, .requirement h4, .requirement h5 {


### PR DESCRIPTION
@fstrr had pointed out that the document has some serious legibility issues at 320px:

<img width="1476" height="814" alt="A screenshot of a mobile viewport showing a single example, where text can barely fit and is effectively writing vertically rather than horizontally." src="https://github.com/user-attachments/assets/d0924f3e-08e9-429e-bbcd-839ccd2f75b4" />

This is caused by the leading margins we added to guidelines and then further to requirements/assertions, which leaves the minimum viewport with barely any room to write in.

This PR conditionalizes those leading margins so they won't apply on mobile.

<img width="335" height="496" alt="A screen of roughly the same area of the page in a mobile viewport, but now the example text has room to fit multiple entire words on each line." src="https://github.com/user-attachments/assets/180ed786-b4b0-4055-8fcd-cd5068f5d608" />
