### PR TITLE
Update 2.4.1 “All elements keyboard actionable” to “All components keyboard operable”

### DIFF
--- a/guidelines/groups/input-operation/keyboard-interface-input.md
+++ b/guidelines/groups/input-operation/keyboard-interface-input.md
@@ -1,6 +1,6 @@
 ---
 children:
-  - all-elements-keyboard-actionable
+  - all-components-keyboard-operable
   - all-content-keyboard-accessible
   - bidirectional-navigation
   - custom-keys-documented

--- a/guidelines/groups/input-operation/keyboard-interface-input/all-components-keyboard-operable.md
+++ b/guidelines/groups/input-operation/keyboard-interface-input/all-components-keyboard-operable.md
@@ -1,0 +1,6 @@
+---
+status: developing
+type: foundational
+---
+
+All :term[components] on the page/view that can be operated by :term[pointer], :term[audio] (voice or other), :term[gesture], :term[camera input], or other means can be operated using :term[keyboard interface] only.

--- a/guidelines/groups/input-operation/keyboard-interface-input/all-content-keyboard-accessible.md
+++ b/guidelines/groups/input-operation/keyboard-interface-input/all-content-keyboard-accessible.md
@@ -14,5 +14,5 @@ Other input modalities include :term[pointing devices], voice and speech recogni
 :::
 
 :::note
-The [All Elements Keyboard-Actionable requirement](#all-elements-keyboard-actionable) allows you to navigate to all actionable elements, but if the next element is 5 screens down, you also need to be able to access all the content. Also, if the content is in expanding :term[sections], you need to not only open them but also access all of the content, not just its actionable elements.
+The [“All components keyboard operable” requirement](#all-components-keyboard-operable) allows you to navigate to all actionable elements, but if the next element is 5 screens down, you also need to be able to access all the content. Also, if the content is in expanding :term[sections], you need to not only open them but also access all of the content, not just its actionable elements.
 :::

--- a/guidelines/groups/input-operation/keyboard-interface-input/all-elements-keyboard-actionable.md
+++ b/guidelines/groups/input-operation/keyboard-interface-input/all-elements-keyboard-actionable.md
@@ -1,6 +1,0 @@
----
-status: developing
-type: foundational
----
-
-All elements that can be controlled or activated by :term[pointer], :term[audio] (voice or other), :term[gesture], :term[camera input], or other means can be controlled or activated from the :term[keyboard interface].


### PR DESCRIPTION
Discussed during [Jan 14, 2026 Input subgroup meeting](https://docs.google.com/document/d/1cxiE1rfpmYs0fmS1CDyRGq-_-_mTghz7vRlGcAhgWLc/edit?tab=t.0#heading=h.roizjgozs68x).

cc: @fstrr / @GreggVan / @ljoakley