### PR TITLE
Requirements: Link to WCAG 2.0 requirements instead of 2.2

### DIFF
--- a/src/pages/requirements.astro
+++ b/src/pages/requirements.astro
@@ -55,7 +55,7 @@ import RequirementsRespec from "@/components/respec/RequirementsRespec.astro";
 					<li>diverse audience, and</li>
 					<li>identify who benefits.</li>
 				</ul>
-				<p>WCAG 3 does not want to advance the WCAG 2 requirement: "Ensure that the revision is 'backwards and forward compatible'". The <a href="https://w3c.github.io/wcag/requirements/22/">WCAG 2.2 Requirements</a> are very specific to WCAG 2.2 and will <em>not</em> be advanced by WCAG 3. The intention is to include WCAG 2 content, but migrate it to a different structure and conformance model. WCAG 3 plans to migrate the content of WCAG 2.2 to WCAG 3.</p>
+				<p>WCAG 3 does not want to advance the WCAG 2 requirement: "Ensure that the revision is 'backwards and forward compatible'". The <a href="https://www.w3.org/TR/wcag2-req/">WCAG 2 Requirements</a> are very specific to WCAG 2 and will <em>not</em> be advanced by WCAG 3. The intention is to include WCAG 2 content, but migrate it to a different structure and conformance model. WCAG 3 plans to migrate the content of WCAG 2.2 to WCAG 3.</p>
 			</section>
 			<section>
 				<h3>WCAG 3 Scope</h3>


### PR DESCRIPTION
This is a follow-up to #391, suggested by Kevin.

The reasoning is that the following are only true of the 2.0 Requirements, not 2.1 or 2.2:

- [Exists in TR space](https://www.w3.org/TR/wcag2-req/)
- Contains the goal referring to backwards/forward compatibility that is explicitly mentioned in this paragraph