### PR TITLE
Change "web site" to "website" in Explainer and Requirements documents

### DIFF
--- a/src/pages/explainer.astro
+++ b/src/pages/explainer.astro
@@ -255,7 +255,7 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
                 <p>Assertions may be used as part of a conformance claim or to support an independent claim of accessibility conformance. 
                     When used for conformance, assertions must be documented within the accessibility conformance claim. 
                     When used outside a conformance claim, the assertion may be
-                    made available through an organization's web site or other materials.</p>
+                    made available through an organization's website or other materials.</p>
                 <p>Assertions include the following information:</p>
                 <ul>
                     <li>The statement about the process being asserted,</li>
@@ -363,13 +363,13 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
 
         <p>Examples of a task flow include:</p>
         <ul>
-            <li>Logging into a web site and being verified as a user;</li>
+            <li>Logging into a website and being verified as a user;</li>
             <li>Ordering an item, including the entire set of tasks from searching for the item, adding it to the
                 shopping cart, paying for it, and receiving confirmation;</li>
             <li>Submitting tax information; and</li>
             <li>Chatting with other users in a virtual reality environment.</li>
         </ul>
-        <p>The product is the combination of all items, views, and task flows that comprise the web site, set of web
+        <p>The product is the combination of all items, views, and task flows that comprise the website, set of web
             pages, web app, etc.</p>
 
         <h4>Conditions</h4>
@@ -473,7 +473,7 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
         <p>The web content publisher should identify all locations of user-generated content (such as commentary on hosted content, product descriptions for consumer to consumer for sale listings, and restaurant reviews) and perform standard accessibility evaluation analysis for each. If there are no accessibility issues, the user-generated content is fully conforming.</p>
         <section>
             <h4>Steps to conform</h4>
-            <p>If accessibility issues are identified, or if the web site author wants to proactively address potential accessibility issues that might arise from user-generated content, then all of the following must be indicated alongside the user-generated content or in an accessibility statement published on the web site or product that is linked from the view or page in a consistent location:</p>
+            <p>If accessibility issues are identified, or if the website author wants to proactively address potential accessibility issues that might arise from user-generated content, then all of the following must be indicated alongside the user-generated content or in an accessibility statement published on the website or product that is linked from the view or page in a consistent location:</p>
             <ol>
                 <li>Clearly identify where user-generated content can be found on the publisher’s digital product (perhaps by id href);</li>
                 <li>Clearly identify the steps taken to encourage accessibility in user-generated content such as prompting the user for alternative text for their uploaded images before they are accepted and prohibiting text attributes except as they are part of semantic markup such as strong, headings, etc.;</li>

--- a/src/pages/requirements.astro
+++ b/src/pages/requirements.astro
@@ -82,7 +82,7 @@ import RequirementsRespec from "@/components/respec/RequirementsRespec.astro";
 			</section>
 			<section>
 				<h3>Large and Dynamic Sites</h3>
-				<p>In addition to the above research, an issue was raised about how to apply accessibility evaluation and conformance to large and dynamic web sites which are updated frequently. This led to development of <a href="https://www.w3.org/TR/accessibility-conformance-challenges/">Challenges with Accessibility Guidelines Conformance and Testing, and Approaches for Mitigating Them</a>. Suggestions in that document are an additional source of input to these requirements.</p>
+				<p>In addition to the above research, an issue was raised about how to apply accessibility evaluation and conformance to large and dynamic websites which are updated frequently. This led to development of <a href="https://www.w3.org/TR/accessibility-conformance-challenges/">Challenges with Accessibility Guidelines Conformance and Testing, and Approaches for Mitigating Them</a>. Suggestions in that document are an additional source of input to these requirements.</p>
 			</section>
 			<section>
 				<h3>Design Principles and Requirements</h3>
@@ -112,7 +112,7 @@ import RequirementsRespec from "@/components/respec/RequirementsRespec.astro";
 					<p>There are several areas for exploration in how conformance can work. These opportunities may or may not be incorporated. They need to work together, and that interplay will be governed by the design principles.</p>
 					<ul>
 						<li><strong>Measurable Guidance</strong>: Certain accessibility guidance is best expressed as a true/false statement. Others far less so. There are needs of people with disabilities, especially cognitive and low vision disabilities, that are better captured by a different type of measurement. WCAG 3 can include guidance (guidelines) that use different means of evaluation beyond just true/false performance or outcome statements, allowing for the inclusion of more accessibility guidance.</li>
-						<li><strong>Scope Options</strong>: WCAG 3 conformance could include web pages, web sites, page sections, individual components, and conformance based on a set of tasks as defined by the author of the site or application. A task-based assessment would allow flexibility for conformance of complex applications that go beyond component/tag assessment or full-page assessment.</li>
+						<li><strong>Scope Options</strong>: WCAG 3 conformance could include web pages, websites, page sections, individual components, and conformance based on a set of tasks as defined by the author of the site or application. A task-based assessment would allow flexibility for conformance of complex applications that go beyond component/tag assessment or full-page assessment.</li>
 						<li><strong>Accessibility Supported</strong>: As the technologies advance, the lines between content, user agents, and assistive technology will continue to shift and blur. Interoperability may be affected by any number of factors outside of the control of the author and publisher of digital content. WCAG 3 can include advice to user agents and assistive technology developers. WCAG 3 does not intend to make authors responsible for interoperability problems beyond a reasonable effort.</li>
 					</ul>
 				</section>


### PR DESCRIPTION
I stumbled across this while reviewing #557, but wanted to keep this separate.

This is consistent with edits we have made to WCAG 2 normative and informative materials.