### PR TITLE
Finish renaming pointer-controllable (was missed in children)

### DIFF
--- a/guidelines/groups/input-operation/pointer-input.md
+++ b/guidelines/groups/input-operation/pointer-input.md
@@ -1,6 +1,6 @@
 ---
 children:
-  - pointer-controllable
+  - pointer-activation-controllable
   - simple-pointer-input-available
   - consistent-pointer-cancellation
   - pointer-pressure-not-relied-on


### PR DESCRIPTION
This was missed in #565, which broke the build.