### PR TITLE
Add support for issueLabel field

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ These are available to multiple data types, as specified in each respective sect
   - `true` indicates the slug to reach the howto is consistent with the folder and filename of the current file
   - A string value indicates an exact slug
   - *This should currently be avoided until the informative documentation is revisited*
+- `issueLabel` - Optional string; specifies the issue label corresponding to a provision
+  - This is only necessary when the label does not match the provision's title, e.g. if a provision is renamed after it was first published
+  - Excludes the "P - " prefix
+  - It may help to think of this as a "legacy title" field
 - `status` - Optional string: one of the status indicators outlined in the Explainer (in lowercase)
 - `title` - Optional title of the guideline, requirement, or term
   - If unspecified, this will be derived from the slug,
@@ -103,7 +107,7 @@ Represents each fourth-level heading that multiple provisions (requirements/asse
 are listed under. Each guideline is defined in a Markdown file, with its child
 provisions located in a subdirectory with the same name.
 
-- Supports [common fields](#common-fields): `children`, `howto`, `status`, `title`
+- Supports [common fields](#common-fields): `children`, `howto`, `issueLabel`, `status`, `title`
   - `status` for guidelines is optional, limited to `developing`, `refining`, `mature`
 - No additional unique fields
 
@@ -111,7 +115,7 @@ provisions located in a subdirectory with the same name.
 
 Represents each fifth-level heading specifying an individual requirement or assertion.
 
-- Supports [common fields](#common-fields): `howto`, `status`, `title`
+- Supports [common fields](#common-fields): `howto`, `issueLabel`, `status`, `title`
   - `status` for requirements and assertions defaults to `exploratory` if not specified
 - `needsAdditionalResearch` - Optional boolean, indicating whether to
   display a "needs additional research" editor's note

--- a/src/components/guidelines/EntryText.astro
+++ b/src/components/guidelines/EntryText.astro
@@ -1,6 +1,7 @@
 ---
 import { getEntry, type CollectionEntry } from "astro:content";
 import { load } from "cheerio";
+import capitalize from "lodash-es/capitalize";
 
 import { computeGuidelineTitle } from "@/lib/guidelines";
 
@@ -49,7 +50,9 @@ function processHtml() {
   if (entry.collection === "requirements") {
     doclinks.push(`
       <p>
-        <a href="https://github.com/w3c/wcag3/issues?q=state%3Aopen%20label%3A%22P%20-%20${encodeURIComponent(entryTitle.replace(/,/g, ""))}%22">
+        <a href="https://github.com/w3c/wcag3/issues?q=state%3Aopen%20label%3A%22P%20-%20${
+          encodeURIComponent((capitalize(entry.data.issueLabel) || entryTitle).replace(/,/g, ""))
+        }%22">
           <svg aria-hidden="true" class="i-list">
             <use xlink:href="img/icons.svg#i-list" />
           </svg>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -58,6 +58,7 @@ export const collections = {
       // Moreover, we can't override generateId for requirements to only use slug,
       // due to duplicates across separate guidelines, e.g. "style-guide"
       children: childrenSchema,
+      issueLabel: z.string().optional(),
       status: parentStatusSchema.optional(),
     }),
   }),
@@ -65,6 +66,7 @@ export const collections = {
     loader: glob({ pattern: "*/*/*.md", base: "./guidelines/groups" }),
     schema: commonChildSchema.extend({
       tags: z.array(reference("tags")).optional(),
+      issueLabel: z.string().optional(),
       needsAdditionalResearch: z.boolean().optional(),
       status: statusSchema.default("exploratory"),
       type: z


### PR DESCRIPTION
This implements and documents an optional `issueLabel` field for provisions.

The goal is to provide backwards compatibility when working on future revisions of the ED when a provision is renamed after it was first published in the WD. Since we now actively link to issue labels based on each provision's name, we should probably avoid changing it in GitHub until we are ready to perform the next republication, so that the links in the existing publication continue to work. In the meantime, this field allows us to continue to link to the label bearing the old name within the ED.

If we don't think that issue links breaking within the ED is a big concern, we don't need to merge this PR.

Also note that this will probably conflict with #575 due to an added `lodash-es` import.