### PR TITLE
Rename "foundational" to "core" within Explainer

### DIFF
--- a/src/pages/explainer.astro
+++ b/src/pages/explainer.astro
@@ -150,7 +150,7 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
         <ul>
             <li>Guidelines (Outcome Statements) - normative
                 <ul>
-                    <li>Foundational Requirements - normative
+                    <li>Core Requirements - normative
                         <ul>
                             <li>How to Documents - informative
                                 <ul>
@@ -191,12 +191,12 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
             learn about and understand the concepts. </p>
         <p>Guidelines are normative.</p>
         <p>Guidelines are <a>technology-agnostic</a> and address functional needs on specific topics, such as contrast, forms, readability, and more.
-          Foundational requirements, supplemental requirements, and assertions that relate 
+          Core requirements, supplemental requirements, and assertions that relate 
             to a Guideline are listed together to encourage adoption of higher levels of accessibility.</p>
 
         <h3>Requirements and Methods</h3>
         <p>Each Guideline contains multiple Requirements:</p>
-        <ul><li>Foundational Requirements will be required to meet base level conformance. They will be part, but not all, of base level
+        <ul><li>Core Requirements will be required to meet base level conformance. They will be part, but not all, of base level
          conformance. This set of requirements will
             cover a similar, but not identical, set of needs as WCAG 2.2 Level AA. </li>
             <li>Supplemental Requirements will be used at all levels of conformance, but testers or policy makers will be able to select 
@@ -205,7 +205,7 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
          <p>Requirements reduce or eliminate barriers that people with disabilities experience. Requirements are designed for use 
             by developers, testers, and other technical specialists.</p>
         <p>Requirements are normative.</p>
-        <p>Each set of Foundational Requirements are organized into a decision tree to show the relationship between requirements and 
+        <p>Each set of Core Requirements are organized into a decision tree to show the relationship between requirements and 
             to allow for accessibility-supported solutions in the future.</p>
 
         <p>Each Requirement is associated with at least one <a>Method</a>.
@@ -223,7 +223,7 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
     
             <h4>Using Assertions</h4>
             <p>Assertions may be used, in addition to Requirements, to support a Guideline. Only assertions included in this document can be used for conformance. Not all Guidelines include Assertions. Guidelines that include Assertions list them with the Requirements. 
-                Organizations can make an Assertion that they followed a procedure as part of a conformance claim.  Assertions build on Foundational Requirements. Assertions cannot be used as alternatives to Foundational Requirements.</p>
+                Organizations can make an Assertion that they followed a procedure as part of a conformance claim.  Assertions build on Core Requirements. Assertions cannot be used as alternatives to Core Requirements.</p>
 
             <div class="ednote">
                 <p>The working group will consider whether assertions may be used to support guidelines when requirements are not available.</p>
@@ -278,7 +278,7 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
                     <p>AG will continue developing requirements and methods. Each publication will include additional examples, and/or more mature examples for public comment.</p>
                     <p>AG's next steps include:</p>
                     <ul>
-                        <li>Define criteria for which requirements are foundational and which are supplemental.</li>
+                        <li>Define criteria for which requirements are core and which are supplemental.</li>
                         <li>Develop mature examples of 2 guidelines with associated requirements, methods, tests, and How to documentation.</li>
                         <li>Mature all guidelines to the developing stage.</li>
                         <li>Further explore how conditional requirements and alternate ways to measure might be used to support Guidelines.</li>
@@ -397,9 +397,9 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
             and vetting the conformance model is a large portion of the work AGWG needs to complete over the next few
             years. Drafts will include maturity models for public review and comment. </p>
 
-        <p>AG is exploring a model based on Foundational Requirements, Supplemental Requirements, and Assertions.</p>
+        <p>AG is exploring a model based on Core Requirements, Supplemental Requirements, and Assertions.</p>
 
-        <p>The most basic level of conformance will require meeting all of the Foundational Requirements. This set will be somewhat
+        <p>The most basic level of conformance will require meeting all of the Core Requirements. This set will be somewhat
             comparable to WCAG 2.2 Level AA.</p>
             
        <p>Higher levels of conformance will be defined and met using Supplemental Requirements and Assertions. AGWG will be exploring
@@ -435,7 +435,7 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
 
             <p>The intent is for the responsibility of testing with user-agents to vary depending on the level of conformance.</p> 
 
-            <p>At the foundational level of conformance assumptions can be made by authors that methods and techniques provided by WCAG 3 work. At higher levels of conformance the author may need to test that a technique works, or check that available user-agents meet the requirement, or a combination of both.</p>
+            <p>At the core level of conformance assumptions can be made by authors that methods and techniques provided by WCAG 3 work. At higher levels of conformance the author may need to test that a technique works, or check that available user-agents meet the requirement, or a combination of both.</p>
 
             <p>This approach means the working group will ensure that methods and techniques included do have reasonably wide and international support from user-agents, and there are sufficient techniques to meet each outcome.</p>
 


### PR DESCRIPTION
This replaces all occurrences of "foundational" with "core" within the Explainer document. Title/lower case is retained in each instance.

Note there is one instance I feel slightly unsure about, "At the core level of conformance"; I'm guessing "foundational" should still be renamed to "core" in this context?

Also note that there are probably other parts of this document that are outdated, such as the discussion of decision trees in the context of Core Requirements.