### PR TITLE
remove “non-decorative image” and “style property” terms

### DIFF
--- a/guidelines/groups/images-and-media/image-alternatives/images-detectable.md
+++ b/guidelines/groups/images-and-media/image-alternatives/images-detectable.md
@@ -6,7 +6,7 @@ type: foundational
 Non-:term[decorative] images are detectable.
 
 :::applies-when
-- content includes :term[non-decorative images].
+- content includes non-:term[decorative] images.
 :::
 
 :::tests

--- a/guidelines/groups/text-and-wording/text-appearance/text-style-readable-minimum.md
+++ b/guidelines/groups/text-and-wording/text-appearance/text-style-readable-minimum.md
@@ -5,7 +5,7 @@ type: foundational
 title: Text style readable (minimum)
 ---
 
-The default/authored presentation of :term[text] :term[style property] meets the corresponding values for the :term[content]'s language, or, if the language is not listed in the table, of the language listed with the most similar orthography.
+The default/authored presentation of :term[text] style property meets the corresponding values for the :term[content]'s language, or, if the language is not listed in the table, of the language listed with the most similar orthography.
 
 :::ednote
 The metrics in the following table are still to be determined; the current content is an example. 

--- a/guidelines/terms/non-decorative-image.md
+++ b/guidelines/terms/non-decorative-image.md
@@ -1,4 +1,0 @@
----
-status: placeholder
-title: non-decorative image
----

--- a/guidelines/terms/style-property.md
+++ b/guidelines/terms/style-property.md
@@ -1,3 +1,0 @@
----
-status: placeholder
----


### PR DESCRIPTION
as suggested over in the email list, this removes two terms:

- **non-decorative image**, as we can link 'decorative' to its definition, which helps with consistency and avoids yet another term, and avoids definition of 'decorative image' counterpart
- **style property**, as the list of properties in the requirement will make clear what we're referring to