### PR TITLE
Fix remaining lodash-es import due to overlapping PRs

### DIFF
--- a/src/components/guidelines/EntryText.astro
+++ b/src/components/guidelines/EntryText.astro
@@ -1,7 +1,7 @@
 ---
 import { getEntry, type CollectionEntry } from "astro:content";
 import { load } from "cheerio";
-import capitalize from "lodash-es/capitalize";
+import capitalize from "lodash/capitalize";
 
 import { computeGuidelineTitle } from "@/lib/guidelines";
 


### PR DESCRIPTION
I had noted that I would likely need to adjust #576 after #575 was merged, but both were merged at the same time, breaking the build. This makes the adjustment that was intended for #576.