### PR TITLE
Update pointer-activation-controllable.md

### DIFF
--- a/guidelines/groups/input-operation/pointer-input/pointer-activation-controllable.md
+++ b/guidelines/groups/input-operation/pointer-input/pointer-activation-controllable.md
@@ -8,8 +8,11 @@ At least one of the following is true for functionality that can be activated us
 No Down Event
 : The :term[down event] of the :term[pointer] is not used to execute any part of the function.
 
-Cancel or Undo
-: Completion of the function is on the :term[up event] and a :term[mechanism] is available to cancel the function before completion, or there is a mechanism to undo the function after completion.
+Cancel
+: Completion of the function is on the :term[up event] and a :term[mechanism] is available to cancel the function before completion.
+
+Undo
+: Completion of the function is on the :term[up event] and a :term[mechanism] and there is a mechanism to undo the function after completion.
 
 Up Reversal
 : The :term[up event] reverses any outcome of the preceding down event.
@@ -31,10 +34,11 @@ Examples of places where action on down event may be essential include a descend
 
 For each element that can be activated with a simple pointer:
  1. Check that the down-event of the pointer is not used to execute any part of the function.
- 2. Check that completion of the function is on the up-event, and a mechanism is available to abort the function before completion or to undo the function after completion.
- 3. Check that the up-event reverses any outcome of the preceding down-event.
- 4. Check that completing the function on the down-event is essential.
+ 2. Check that completion of the function is on the up-event, and a mechanism is available to cancel the function before completion.
+ 3. Check that completion of the function is on the up-event, and a mechanism is available to undo the function after completion.
+ 4. Check that the up-event reverses any outcome of the preceding down-event.
+ 5. Check that completing the function on the down-event is essential.
 
 **Expected results**
-- Any of #1, #2, #3, or #4 is true.
+- Any of #1, #2, #3, #4, or #5 is true.
 :::


### PR DESCRIPTION
Subgroup now thinks that “cancel or undo” should be two distinct options, rather than one combined option.

From subgroup call 25 February.  This can wait until next publication, as this proposed edit was only surfaced because of ACT rule writing activity.