### PR TITLE
Fix TS warnings and make config stricter to surface them as errors

### DIFF
--- a/src/components/informative/Breadcrumbs.astro
+++ b/src/components/informative/Breadcrumbs.astro
@@ -21,7 +21,7 @@ function resolveSlug(segment: Segment) {
   return segment.id.slice(segment.id.lastIndexOf("/") + 1);
 }
 
-const resolvedSegments: ResolvedSegment[] = segments.map((segment, i) => ({
+const resolvedSegments: ResolvedSegment[] = segments.map((segment) => ({
   slug: resolveSlug(segment),
   title: segment.title,
 }));

--- a/src/layouts/InformativeLayout.astro
+++ b/src/layouts/InformativeLayout.astro
@@ -5,7 +5,6 @@ import Breadcrumbs from "@/components/informative/Breadcrumbs.astro";
 import DraftBanner from "@/components/informative/DraftBanner.astro";
 import Header from "@/components/informative/Header.astro";
 import WaiFooter from "@/components/informative/WaiFooter.astro";
-import type { InformativeGuideline, InformativeRequirement } from "@/lib/informative";
 
 interface Props {
   breadcrumbSegments?: ComponentProps<typeof Breadcrumbs>["segments"];

--- a/src/lib/informative.ts
+++ b/src/lib/informative.ts
@@ -1,4 +1,4 @@
-import type { GetStaticPaths, Params } from "astro";
+import type { GetStaticPaths } from "astro";
 import {
   getCollection,
   getEntry,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,7 +5,7 @@ import GithubSlugger from "github-slugger";
 
 import { informativeSlug } from "./lib/constants";
 
-const processInformative: MiddlewareHandler = async ({ request, url }, next) => {
+const processInformative: MiddlewareHandler = async ({ url }, next) => {
   if (!url.pathname.startsWith(import.meta.env.BASE_URL + informativeSlug)) return next();
 
   const response = await next();

--- a/src/pages/informative/index.astro
+++ b/src/pages/informative/index.astro
@@ -1,6 +1,4 @@
 ---
-import capitalize from "lodash/capitalize";
-
 import InformativeLayout from "@/layouts/InformativeLayout.astro";
 import RequirementsList from "@/components/informative/RequirementsList.astro";
 import { informativeSlug } from "@/lib/constants";
@@ -37,7 +35,7 @@ for (const { id } of informativeGroups) {
   <h1>Indexes</h1>
   <ul>
     {
-      Object.entries(informativeRelatedTypes).map(([type, { slug, title }]) => (
+      Object.values(informativeRelatedTypes).map(({ slug, title }) => (
         <li>
           <a href={`${import.meta.env.BASE_URL}${informativeSlug}/${slug}/`}>{title}</a>
         </li>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,9 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
   },
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],


### PR DESCRIPTION
When verifying #650, I realized `npm run check` was emitting warnings. This fixes them, and elevates them to errors so they don't slip by in the future. (I suspect these were all from #627.)