### PR TITLE
Simplify simple-pointer-input-available.md

### DIFF
--- a/guidelines/groups/input-operation/pointer-input/simple-pointer-input-available.md
+++ b/guidelines/groups/input-operation/pointer-input/simple-pointer-input-available.md
@@ -3,7 +3,7 @@ status: developing
 type: foundational
 ---
 
-All functionality and content available using :term[complex pointer inputs] is also available using a :term[simple pointer input] or a sequence of simple pointer inputs that do not require timing.
+All functionality and content available using :term[complex pointer inputs] is also available using one or more :term[simple pointer inputs] that do not require timing.
 
 :::example
 Examples of complex pointer inputs:

--- a/guidelines/groups/input-operation/pointer-input/simple-pointer-input-available.md
+++ b/guidelines/groups/input-operation/pointer-input/simple-pointer-input-available.md
@@ -3,7 +3,7 @@ status: developing
 type: foundational
 ---
 
-All functionality and content available using :term[complex pointer inputs] is also available using one or more :term[simple pointer inputs] that do not require timing.
+All functionality and content available using :term[complex pointer inputs] is also available using a :term[simple pointer input], or a sequence of simple pointer inputs that do not require timing.
 
 :::example
 Examples of complex pointer inputs:


### PR DESCRIPTION
Change:
> …also available using a simple pointer input or a sequence of simple pointer inputs that do not require timing

to:
> …also available using one or more simple pointer inputs that do not require timing

Rational:  simpler language and “sequence” implies something more involved than merely “one or more” (i.e., the order of the inputs is not relevant to the requirement).

From inputs subgroup call 4/22