### PR TITLE
Fix `single pointer` → `simple pointer` typo in glossary

### DIFF
--- a/guidelines/terms/complex-pointer-input.md
+++ b/guidelines/terms/complex-pointer-input.md
@@ -4,7 +4,7 @@ synonyms:
   - complex pointer inputs
 ---
 
-any pointer input other than a :term[single pointer input]
+any pointer input other than a :term[simple pointer input]
 
 :::example
 - Double clicking

--- a/guidelines/terms/simple-pointer-input.md
+++ b/guidelines/terms/simple-pointer-input.md
@@ -2,7 +2,7 @@
 status: developing
 ---
 
-input event that involves only a single 'click' event or a 'button down' and 'button up' pair of events with no movement between
+:term[single pointer input] event that involves only a single 'click' event or a 'button down' and 'button up' pair of events with no movement between
 
 :::example
 Examples of things that would _not_ be considered simple pointer inputs:


### PR DESCRIPTION
The glossary currently defines a “[complex pointer input](https://w3c.github.io/wcag3/guidelines/#dfn-complex-pointer-input)” as:

> any pointer input other than a [<mark>**single**</mark> pointer input](https://w3c.github.io/wcag3/guidelines/#dfn-single-pointer-input)

...but we mean:

> any pointer input other than a [<mark>**simple**</mark> pointer input](https://w3c.github.io/wcag3/guidelines/#dfn-simple-pointer-input)

This PR fixes that, and also clarifies that a [_simple_ pointer input](https://w3c.github.io/wcag3/guidelines/#dfn-simple-pointer-input) must also be a [_single_ pointer input](https://w3c.github.io/wcag3/guidelines/#dfn-single-pointer-input).