### PR TITLE
Refine simple pointer input definition

### DIFF
--- a/guidelines/terms/complex-pointer-input.md
+++ b/guidelines/terms/complex-pointer-input.md
@@ -7,6 +7,7 @@ synonyms:
 any pointer input other than a :term[single pointer input]
 
 :::example
+- Press and hold
 - Double clicking
 - Multipoint clicking
 - Dragging (single or multipoint)

--- a/guidelines/terms/down-event.md
+++ b/guidelines/terms/down-event.md
@@ -1,5 +1,7 @@
 ---
 status: developing
+synonyms:
+  - down
 ---
 
 platform event that occurs when the trigger stimulus of a pointer is depressed

--- a/guidelines/terms/simple-pointer-input.md
+++ b/guidelines/terms/simple-pointer-input.md
@@ -2,7 +2,7 @@
 status: developing
 ---
 
-input event that involves only a single 'click' event or a 'button down' and 'button up' pair of events with no movement between
+:term[single pointer input] event that involves only a single 'click' event or a :term[down]-:term[up] pair of events with no pointer movement required between, and no outcome difference based on length of time between :term[down] and :term[up] events.
 
 :::example
 Examples of things that would _not_ be considered simple pointer inputs:

--- a/guidelines/terms/up-event.md
+++ b/guidelines/terms/up-event.md
@@ -1,5 +1,7 @@
 ---
 status: developing
+synonyms:
+  - up
 ---
 
 platform event that occurs when the trigger stimulus of a pointer is released


### PR DESCRIPTION
Refines the definition of “[simple pointer input](https://w3c.github.io/wcag3/guidelines/#dfn-simple-pointer-input)” following subgroup rewriting consensus.