### PR TITLE
Remove stray `howto` from “Keyboard focus appearance” guideline

### DIFF
--- a/guidelines/groups/interactive-components/keyboard-focus-appearance.md
+++ b/guidelines/groups/interactive-components/keyboard-focus-appearance.md
@@ -4,7 +4,6 @@ children:
   - focus-indicator-contrast-sufficient
   - focus-indicator-size-sufficient
   - focus-indicator-style-guide
-howto: focus-appearance
 status: developing
 ---
 


### PR DESCRIPTION
Looks like one `howto` may have been missed in #331’s deprecation of it.

Resolves #405.