### PR TITLE
Fix remark plugin logic to work on Windows

### DIFF
--- a/src/lib/markdown/guidelines.ts
+++ b/src/lib/markdown/guidelines.ts
@@ -3,15 +3,17 @@ import type { ContainerDirective } from "mdast-util-directive";
 import { visit } from "unist-util-visit";
 import type { VFile } from "vfile";
 
+import { join, sep } from "path";
+
 const groupsPath = `guidelines/groups`;
-const isGuidelineFile = (file: VFile) => file.dirname?.startsWith(`${file.cwd}/${groupsPath}`);
+const isGuidelineFile = (file: VFile) => file.dirname?.startsWith(join(file.cwd, groupsPath));
 
 type GuidelineFileType = "group" | "guideline" | "requirement";
 
 function getGuidelineFileType(file: VFile): GuidelineFileType | null {
   if (!isGuidelineFile(file)) return null;
-  const remainingPath = file.dirname!.replace(`${file.cwd}/${groupsPath}/`, "");
-  const segments = remainingPath?.split("/");
+  const remainingPath = file.dirname!.replace(join(file.cwd, groupsPath) + sep, "");
+  const segments = remainingPath?.split(sep);
   if (segments.length === 0) return "group";
   if (segments.length === 1) return "guideline";
   if (segments.length === 2) return "requirement";
@@ -29,7 +31,7 @@ function expectGuidelineFileType(
     file.fail(`${directiveName} expected at ${expectedType} level but found at ${type} level`);
 }
 
-const isTermFile = (file: VFile) => file.dirname?.startsWith(`${file.cwd}/guidelines/terms`);
+const isTermFile = (file: VFile) => file.dirname?.startsWith(join(file.cwd, "guidelines", "terms"));
 
 /** Adds standard editor's note to terms with empty content. */
 const addEmptyTermNote: RemarkPlugin = () => (tree, file) => {

--- a/src/lib/markdown/guidelines.ts
+++ b/src/lib/markdown/guidelines.ts
@@ -153,7 +153,7 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
             value: "Recommended internal documentation (Informative):",
           },
         ];
-      } else file.fail(`Unrecognized leaf directive ::${node.name}`);
+      }
     }
   });
 };

--- a/src/lib/markdown/informative.ts
+++ b/src/lib/markdown/informative.ts
@@ -1,10 +1,12 @@
 import { rehypeHeadingIds, type RehypePlugin, type RemarkPlugin } from "@astrojs/markdown-remark";
 import type { VFile } from "vfile";
 
+import { join } from "path";
+
 import { informativeSlug } from "../constants";
 
 export const isInformativeFile = (file: VFile) =>
-  file.dirname?.startsWith(`${file.cwd}/${informativeSlug}`);
+  file.dirname?.startsWith(join(file.cwd, informativeSlug));
 
 const customDirectives: RemarkPlugin = () => (tree, file) => {
   if (!isInformativeFile(file)) return;


### PR DESCRIPTION
While testing #670 on Windows, I discovered a bigger problem: I unwittingly hard-coded *nix path separators in our Markdown plugins.

This PR fixes all references to path separators to use `join` or `sep` from the `path` module. It causes no build changes on Linux, and the build now works on Windows.

I also caught and removed one residual check for unrecognized directives; I had previously intended to move all of these to `checkDirectives` in `src/lib/markdown/common.ts` (and it is already covering this case).