### PR TITLE
Change all instances of z.object to z.strictObject for validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,6 @@ These are available to multiple data types, as specified in each respective sect
 
 - `children` - A list containing every slug found under a parent entry's corresponding subdirectory,
   in the order they are intended to be listed in the document
-- `howto` - *Deprecated* Optional boolean or string indicating the presence of a howto page
-  for the given guideline or requirement
-  - `true` indicates the slug to reach the howto is consistent with the folder and filename of the current file
-  - A string value indicates an exact slug
-  - *This should currently be avoided until the informative documentation is revisited*
 - `issueLabel` - Optional string; specifies the issue label corresponding to a provision
   - This is only necessary when the label does not match the provision's title, e.g. if a provision is renamed after it was first published
   - Excludes the "P - " prefix

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -36,7 +36,7 @@ export const collections = {
     loader: file("./guidelines/groups.json", {
       parser: stringArrayParser,
     }),
-    schema: z.object({
+    schema: z.strictObject({
       // This _should_ be able to use reference("groups"),
       // but it's not finding some of them even when they exist?
       id: z.string(),
@@ -44,7 +44,7 @@ export const collections = {
   }),
   groups: defineCollection({
     loader: glob({ pattern: ["*.json"], base: "./guidelines/groups" }),
-    schema: z.object({
+    schema: z.strictObject({
       children: childrenSchema,
       status: parentStatusSchema.optional(),
       title: z.string().optional(),
@@ -52,7 +52,7 @@ export const collections = {
   }),
   guidelines: defineCollection({
     loader: glob({ pattern: "*/*.md", base: "./guidelines/groups" }),
-    schema: z.object({
+    schema: z.strictObject({
       // Note: can't use references for children while relying on default ids,
       // since auto-generated ids include every * segment rather than only the last.
       // Moreover, we can't override generateId for requirements to only use slug,
@@ -65,7 +65,7 @@ export const collections = {
   }),
   requirements: defineCollection({
     loader: glob({ pattern: "*/*/*.md", base: "./guidelines/groups" }),
-    schema: z.object({
+    schema: z.strictObject({
       tags: z.array(reference("tags")).optional(),
       issueLabel: z.string().optional(),
       needsAdditionalResearch: z.boolean().optional(),
@@ -81,7 +81,7 @@ export const collections = {
   }),
   terms: defineCollection({
     loader: glob({ pattern: "*.md", base: "./guidelines/terms" }),
-    schema: z.object({
+    schema: z.strictObject({
       status: statusSchema.optional(),
       synonyms: z.array(z.string()).min(1).optional(),
       title: z.string().optional(),


### PR DESCRIPTION
This performs stricter validation on frontmatter, causing builds to fail if unknown keys are encountered.

(This is intended to flag the sort of issue that #667 fixed.)

While I was at it, I also removed some stale docs around the `howto` field which was already removed when the informative structure was added.