### PR TITLE
Fix typos in glossary and preselections-visible documentation

### DIFF
--- a/guidelines/groups/process-and-task-completion/avoid-deception/preselections-visible.md
+++ b/guidelines/groups/process-and-task-completion/avoid-deception/preselections-visible.md
@@ -8,9 +8,9 @@ During the completion of a :term[process], preselected options that impact finan
 :::tests
 <b>Procedure</b>
 
-For all options that affect finance, privacy and safety"
+For all options that affect finance, privacy and safety:
 1. Check that the options are visible when completing a process.
-2. Check that that they are programmatically available before completing the process.
+2. Check that they are programmatically available before completing the process.
 
 <b>Expected results</b>
 * #1 and #2 are true.

--- a/guidelines/terms/common-keyboard-navigation-technique.md
+++ b/guidelines/terms/common-keyboard-navigation-technique.md
@@ -5,5 +5,5 @@ status: developing
 keyboard navigation technique that is the same across most or all applications and platforms and can therefore be relied upon by users who need to navigate by keyboard alone
 
 :::note
-A sufficient listing of common keyboard navigation techniques for use by authors can be found in the  [Standard Keyboard Navigation &amp; Operation Keys and Techniques](https://github.com/w3c/wcag3/wiki/Standard-Keyboard-Navigation-&-Operation-Keys-and-Techniques)
+A sufficient listing of common keyboard navigation techniques for use by authors can be found in the [Standard Keyboard Navigation &amp; Operation Keys and Techniques](https://github.com/w3c/wcag3/wiki/Standard-Keyboard-Navigation-&-Operation-Keys-and-Techniques)
 :::


### PR DESCRIPTION
This pull request makes a minor correction to the procedure section of the guideline for process completion, clarifying the punctuation and fixing a typo.

* Fixed punctuation and corrected a repeated word in the procedure for checking visibility of options that affect finance, privacy, and safety in `preselections-visible.md`.