### PR TITLE
Clean up defunct properties in respecConfigs, and add class="remove"

### DIFF
--- a/src/components/respec/ExplainerRespec.astro
+++ b/src/components/respec/ExplainerRespec.astro
@@ -31,12 +31,6 @@
   }
 
   respecConfig = {
-    // embed RDFa data in the output
-    trace: true,
-    doRDFa: "1.1",
-    includePermalinks: true,
-    permalinkEdge: true,
-    permalinkHide: false,
     // specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
     specStatus: "ED",
     //crEnd:                "2012-04-30",

--- a/src/components/respec/GuidelinesRespec.astro
+++ b/src/components/respec/GuidelinesRespec.astro
@@ -351,12 +351,6 @@ import GuidelinesRespecDev from "./GuidelinesRespecDev.astro";
   }
 
   respecConfig = {
-    // embed RDFa data in the output
-    trace: true,
-    doRDFa: "1.1",
-    includePermalinks: true,
-    permalinkEdge: true,
-    permalinkHide: false,
     // specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
     specStatus: "ED",
     //crEnd:                "2012-04-30",

--- a/src/components/respec/RequirementsRespec.astro
+++ b/src/components/respec/RequirementsRespec.astro
@@ -1,18 +1,11 @@
-<script is:inline>
+<script is:inline class="remove">
   respecConfig = {
-    // embed RDFa data in the output
-    trace: true,
-    doRDFa: "1.1",
-    includePermalinks: true,
-    permalinkEdge: true,
-    permalinkHide: false,
     // specification status (e.g., WD, LC, NOTE, etc.). If in doubt use ED.
     specStatus: "DNOTE",
     noRecTrack: true,
     //crEnd:                "2012-04-30",
     //perEnd:               "2013-07-23",
     publishDate: "2026-03-03",
-    diffTool: "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
 
     // the specifications short name, as in https://www.w3.org/TR/short-name/
     shortName: "wcag-3.0-requirements",


### PR DESCRIPTION
This removes `respecConfig` properties that are deprecated/defunct. See https://github.com/w3c/wcag/pull/5147 for details on when these properties became unsupported.

I exported HTML before/after the changes and diffed the output to confirm no changes other than the config itself. This also led me to discover that the `script` element including `respecConfig` was not being stripped from the Requirements document, so I added `class="remove"` (which was already in the other two).