### PR TITLE
Page/view title available - Updates after survey

### DIFF
--- a/guidelines/groups/layout/user-orientation/page-view-title-available.md
+++ b/guidelines/groups/layout/user-orientation/page-view-title-available.md
@@ -5,17 +5,29 @@ status: developing
 ---
 
 :term[Pages]/:term[views] have a title that describes the name, topic or purpose.
+The :term[page]/:term[view] has a title that describes its name, topic or purpose.
+Except when: The technology has no way to include a title.
+
 
 :::except-when
-- The presented content has no way to include a title.
+- The technology has no way to include a title.
 :::
 
 :::tests
-<b>Procedure</b>
+<b>Procedure: Ensure the page/view title is meaningful</b>
 
 For each page/view:
 1. Examine the source code of the HTML document and check that the first `title` element is not-empty.
 2. Check that the title element describes the document.
+
+<b>Expected results</b>
+* #1 and #2 are true.
+
+<b>Procedure: Verify that the page/view has no available mechanism to define a title</b>
+
+For each page/view where no title element is present:
+1. Determine whether the current page/view allows setting the HTML document `title` element.
+2. If the page/view is rendered within the current document context (e.g. modal dialog, popup, etc.) and does not provide a mechanism to set a document-level `title`, the exception applies.
 
 <b>Expected results</b>
 * #1 and #2 are true.

--- a/guidelines/groups/layout/user-orientation/page-view-title-available.md
+++ b/guidelines/groups/layout/user-orientation/page-view-title-available.md
@@ -4,9 +4,7 @@ type: foundational
 status: developing
 ---
 
-:term[Pages]/:term[views] have a title that describes the name, topic or purpose.
 The :term[page]/:term[view] has a title that describes its name, topic or purpose.
-Except when: The technology has no way to include a title.
 
 
 :::except-when

--- a/guidelines/groups/layout/user-orientation/page-view-title-available.md
+++ b/guidelines/groups/layout/user-orientation/page-view-title-available.md
@@ -12,23 +12,3 @@ Except when: The technology has no way to include a title.
 :::except-when
 - The technology has no way to include a title.
 :::
-
-:::tests
-<b>Procedure: Ensure the page/view title is meaningful</b>
-
-For each page/view:
-1. Examine the source code of the HTML document and check that the first `title` element is not-empty.
-2. Check that the title element describes the document.
-
-<b>Expected results</b>
-* #1 and #2 are true.
-
-<b>Procedure: Verify that the page/view has no available mechanism to define a title</b>
-
-For each page/view where no title element is present:
-1. Determine whether the current page/view allows setting the HTML document `title` element.
-2. If the page/view is rendered within the current document context (e.g. modal dialog, popup, etc.) and does not provide a mechanism to set a document-level `title`, the exception applies.
-
-<b>Expected results</b>
-* #1 and #2 are true.
-:::

--- a/informative/act-rules/web/html-page-non-empty-title.md
+++ b/informative/act-rules/web/html-page-non-empty-title.md
@@ -91,7 +91,6 @@ This page does not have a title element.
 <html>
 	<h1>this page has no title</h1>
 </html>
-
 ```
 
 ### Failed example 2

--- a/informative/act-rules/web/html-page-non-empty-title.md
+++ b/informative/act-rules/web/html-page-non-empty-title.md
@@ -138,7 +138,7 @@ This page has a title element that only contains a separator character.
 </html>
 ```
 
-### Inappplicable example 1
+### Inapplicable example 1
 
 This title element is a child of an svg element.
 

--- a/informative/act-rules/web/html-page-non-empty-title.md
+++ b/informative/act-rules/web/html-page-non-empty-title.md
@@ -1,0 +1,150 @@
+---
+title: HTML page has non-empty title
+provisions:
+  - page-view-title-available
+---
+
+This rule checks that a non-embedded HTML page has a non-empty title.
+
+## Applicability
+
+This rule applies to the root element of the web page, if it is an html element.
+
+## Expectation 1
+
+Each target element has at least one descendant that is a title element.
+
+## Expectation 2
+
+For each target element, the first HTML title element that is a descendant of the document element has children that are text nodes that are not only whitespace.
+
+## Examples
+
+### Passed example 1
+
+This page has a title element with content.
+
+```
+<html>
+	<title>This page has a title</title>
+</html>
+```
+
+### Passed example 2
+
+This page has a title element that serves as the title for the page and the iframe since the iframe does not have its own.
+
+```
+<html>
+	<title>This page gives a title to an iframe</title>
+	<iframe src="/test-assets/sc2-4-2-title-page-without-title.html"></iframe>
+</html>
+```
+
+### Passed example 3
+
+This page has two title elements with content.
+
+```
+<html>
+	<head>
+		<title>Title of the page.</title>
+	</head>
+	<body>
+		<title>Title of the page.</title>
+	</body>
+</html>
+```
+
+### Passed example 4
+
+This page has one title element with content, which is within the body element.
+
+```
+<html>
+	<body>
+		<title>Title of the page.</title>
+	</body>
+</html>
+```
+
+### Passed example 5
+
+This page has two title elements and only the first has content.
+
+```
+<html>
+	<head>
+		<title>Title of the page.</title>
+	</head>
+	<body>
+		<title></title>
+	</body>
+</html>
+```
+
+### Failed example 1
+
+This page does not have a title element.
+
+```
+<html>
+	<h1>this page has no title</h1>
+</html>
+
+```
+
+### Failed example 2
+
+This page has a title element that is empty.
+
+```
+<html>
+	<title></title>
+</html>
+```
+
+### Failed example 3
+
+This page does not have a title element. The title element in the content of the iframe does not function as the title for the entire page.
+
+```
+<html>
+	<iframe src="/test-assets/sc2-4-2-title-page-with-title.html"></iframe>
+</html>
+```
+
+### Failed Example 4
+
+This page has two title elements and the first is empty.
+
+```
+<html>
+	<head>
+		<title></title>
+	</head>
+	<body>
+		<title>Title of the page.</title>
+	</body>
+</html>
+```
+
+### Failed example 5
+
+This page has a title element that only contains a separator character.
+
+```
+<html>
+	<title> </title>
+</html>
+```
+
+### Inappplicable example 1
+
+This title element is a child of an svg element.
+
+```
+<svg xmlns="http://www.w3.org/2000/svg">
+  <title>This is an SVG</title>
+</svg>
+```

--- a/informative/act-rules/web/html-page-non-empty-title.md
+++ b/informative/act-rules/web/html-page-non-empty-title.md
@@ -25,7 +25,7 @@ For each target element, the first HTML title element that is a descendant of th
 This page has a title element with content.
 
 ```
-<html>
+<html lang="en">
 	<title>This page has a title</title>
 </html>
 ```
@@ -35,7 +35,7 @@ This page has a title element with content.
 This page has a title element that serves as the title for the page and the iframe since the iframe does not have its own.
 
 ```
-<html>
+<html lang="en">
 	<title>This page gives a title to an iframe</title>
 	<iframe src="/test-assets/sc2-4-2-title-page-without-title.html"></iframe>
 </html>
@@ -46,7 +46,7 @@ This page has a title element that serves as the title for the page and the ifra
 This page has two title elements with content.
 
 ```
-<html>
+<html lang="en">
 	<head>
 		<title>Title of the page.</title>
 	</head>
@@ -61,7 +61,7 @@ This page has two title elements with content.
 This page has one title element with content, which is within the body element.
 
 ```
-<html>
+<html lang="en">
 	<body>
 		<title>Title of the page.</title>
 	</body>
@@ -73,7 +73,7 @@ This page has one title element with content, which is within the body element.
 This page has two title elements and only the first has content.
 
 ```
-<html>
+<html lang="en">
 	<head>
 		<title>Title of the page.</title>
 	</head>
@@ -88,7 +88,7 @@ This page has two title elements and only the first has content.
 This page does not have a title element.
 
 ```
-<html>
+<html lang="en">
 	<h1>this page has no title</h1>
 </html>
 ```
@@ -98,7 +98,7 @@ This page does not have a title element.
 This page has a title element that is empty.
 
 ```
-<html>
+<html lang="en">
 	<title></title>
 </html>
 ```
@@ -108,7 +108,7 @@ This page has a title element that is empty.
 This page does not have a title element. The title element in the content of the iframe does not function as the title for the entire page.
 
 ```
-<html>
+<html lang="en">
 	<iframe src="/test-assets/sc2-4-2-title-page-with-title.html"></iframe>
 </html>
 ```
@@ -118,7 +118,7 @@ This page does not have a title element. The title element in the content of the
 This page has two title elements and the first is empty.
 
 ```
-<html>
+<html lang="en">
 	<head>
 		<title></title>
 	</head>
@@ -133,7 +133,7 @@ This page has two title elements and the first is empty.
 This page has a title element that only contains a separator character.
 
 ```
-<html>
+<html lang="en">
 	<title> </title>
 </html>
 ```

--- a/informative/act-rules/web/html-page-title-descriptive.md
+++ b/informative/act-rules/web/html-page-title-descriptive.md
@@ -1,0 +1,261 @@
+---
+title: HTML page title is descriptive
+provisions:
+  - page-view-title-available
+---
+
+This rule checks that the first title in an HTML web page describes the topic or purpose of that page.
+
+## Applicability
+
+This rule applies to the document title of each html web page, except if one of the following is true:
+* The html web page has no document title; or
+* The document title contains only whitespace text nodes.
+
+## Expectation 1
+
+The target element describes the topic or purpose of the overall content of the document.
+
+## Examples
+
+### Passed example 1
+
+This title element describes the content of the document.
+
+```
+<html lang="en">
+	<head>
+		<title>Clementine harvesting season</title>
+	</head>
+	<body>
+		<p>
+			Clementines will be ready to harvest from late October through February.
+		</p>
+	</body>
+</html>
+```
+
+### Passed example 2
+
+This title element, the first of two, describes the content of the document.
+
+```
+<html lang="en">
+	<head>
+		<title>Clementine harvesting season</title>
+		<title>Second title is ignored</title>
+	</head>
+	<body>
+		<p>
+			Clementines will be ready to harvest from late October through February.
+		</p>
+	</body>
+</html>
+```
+
+### Passed example 3
+
+This title element, which is within the body, describes the content of the document. Even though it is not placed within the head element, as expected according to the HTML specification, the rule still passes because the browser fixes it and it doesn’t cause any known accessibility issues.
+
+```
+<html lang="en">
+	<head> </head>
+	<body>
+		<title>Clementine harvesting season</title>
+		<p>
+			Clementines will be ready to harvest from late October through February.
+		</p>
+	</body>
+</html>
+```
+
+### Passed example 4
+
+The title describes the consistent purpose of the page, even though the actual content varies depending on previous user input. Since this is a review page where details such as items, shipping address, and totals may change, the title focuses on the page’s function rather than its variable content.
+
+```
+<html lang="en">
+	<head>
+		<title>Order review - Acme Shop</title>
+	</head>
+	<body>
+		<h1>Review your order</h1>
+		<ul>
+			<li>
+				<p>Item: Blue running shoes (size 42)</p>
+				<p>Shipping address: 123 Main St</p>
+				<p>Total: $89.99</p>
+			</li>
+			<li>
+				<p>Item: Red running shoes (size 43)</p>
+				<p>Shipping address: 123 Main St</p>
+				<p>Total: $99.99</p>
+			</li>
+		</ul>
+	</body>
+</html>
+```
+
+### Passed example 5
+
+The title describes the specific purpose of each step within the multi-step process. Although all steps belong to the same overall workflow (e.g., checkout), each page represents a distinct stage with its own function (such as shipping, billing, or payment), and the title reflects this specific purpose.
+
+```
+<html lang="en">
+	<head>
+		<title>Checkout - Shipping Address</title>
+	</head>
+	<body>
+		<h1>Checkout</h1>
+		<h2>Shipping Address</h2>
+		…
+	</body>
+</html>
+```
+
+### Passed example 6
+
+The title describes the overall purpose of the page. Although the page contains a multi-step process with sections that are progressively enabled as the user completes each step, all steps are part of a single, unified page. Therefore, the title reflects the overall process (checkout) rather than the individual steps.
+
+```
+<html lang="en">
+	<head>
+		<title>Checkout</title>
+	</head>
+	<body>
+		<h1>Checkout</h1>
+		<section aria-labelledby=”step1”>
+			<h2>
+				<button aria-expanded=”true” id=”step1”>Shipping Address</button>
+			</h2>
+			…
+		</section>
+		<section aria-labelledby=”step2”>
+			<h2>
+				<button aria-expanded=”false” aria-disabled=”true”  id=”step2”>Billing Address</button>
+			</h2>
+		</section>
+		<section aria-labelledby=”step3”>
+			<h2>
+				<button aria-expanded=”false” aria-disabled=”true”  id=”step3”>Billing Address</button>
+			</h2>
+		</section>
+	</body>
+</html>
+```
+
+### Passed example 7
+
+The title describes the overall purpose of the page. While the content may change dynamically based on applied filters, these changes do not alter the page’s purpose and the title remains consistent.
+
+```
+<html lang="en">
+	<head>
+		<title>Apparel - Acme Shop</title>
+	</head>
+	<body>
+		<h1>Apparel</h1>
+		<p>Filters applied: Color: Red, Size: M</p>
+		<ul>
+			<li>Red polo shirt, size M</li>
+			<li>Red hoodie, size M</li>
+		</ul>
+		…
+	</body>
+</html>
+```
+
+### Failed example 1
+
+This title element does not describe the content of the document.
+
+```
+<html lang="en">
+	<head>
+		<title>Apple harvesting season</title>
+	</head>
+	<body>
+		<p>
+			Clementines will be ready to harvest from late October through February.
+		</p>
+	</body>
+</html>
+```
+
+### Failed example 2
+
+This title element, the first of two, does not describe the content of the document. Most browsers, and this rule, only look at the first title element.
+
+```
+<html lang="en">
+	<head>
+		<title>First title is incorrect</title>
+		<title>Clementine harvesting season</title>
+	</head>
+	<body>
+		<p>
+			Clementines will be ready to harvest from late October through February.
+		</p>
+	</body>
+</html>
+```
+
+### Failed example 3
+
+This page has a generic document title. The title contains the website name, but does not describe the page.
+
+```
+<html lang="en">
+	<head>
+		<title>University of Arkham</title>
+	</head>
+	<body>
+		<h1>Search results for "accessibility" at the University of Arkham</h1>
+		<p>None</p>
+	</body>
+</html>
+```
+
+### Failed Example 4
+
+The same title “Shoes - Acme Shop” is used for different pages covering all shoes, men's shoes, and women's shoes. This title element does not describe the content of the document. The title is shared across multiple pages with different purposes, failing to distinguish between them.
+
+```
+<html lang="en">
+	<head>
+		<title>Shoes - Acme Shop</title>
+	</head>
+	<body>
+		<h1>Men's shoes</h1>
+		<p>Browse our collection of men's footwear.</p>
+	</body>
+</html>
+```
+
+### Failed example 5
+
+The title does not sufficiently describe the specific purpose of the current step. Although the page is part of a multi-step process, each step represents a distinct view with its own function. Using a generic title such as "Checkout" fails to identify the specific purpose of the page (e.g., shipping, billing, or payment).
+
+```
+<html lang="en">
+	<head>
+		<title>Checkout</title>
+	</head>
+	<body>
+		<h1>Checkout</h1>
+		<h2>Shipping Address</h2>
+		…
+	</body>
+</html>
+```
+
+### Inappplicable example 1
+
+This title element is a child of an svg element.
+
+```
+<svg xmlns="http://www.w3.org/2000/svg">
+  <title>This is a circle</title>
+  <circle cx="150" cy="75" r="50" fill="green"></circle>
+</svg>
+```

--- a/informative/act-rules/web/html-page-title-descriptive.md
+++ b/informative/act-rules/web/html-page-title-descriptive.md
@@ -249,7 +249,7 @@ The title does not sufficiently describe the specific purpose of the current ste
 </html>
 ```
 
-### Inappplicable example 1
+### Inapplicable example 1
 
 This title element is a child of an svg element.
 

--- a/informative/guidelines/layout/user-orientation/page-view-title-available.md
+++ b/informative/guidelines/layout/user-orientation/page-view-title-available.md
@@ -21,4 +21,3 @@ For each page/view where no title element is present:
 
 <b>Expected results</b>
 * #1 and #2 are true.
-:::

--- a/informative/guidelines/layout/user-orientation/page-view-title-available.md
+++ b/informative/guidelines/layout/user-orientation/page-view-title-available.md
@@ -1,1 +1,24 @@
 ## Tests
+
+<i>Ensure the page/view title is meaningful</i>
+
+<b>Procedure</b>
+
+For each page/view:
+1. Examine the source code of the HTML document and check that the first `title` element is not-empty.
+2. Check that the title element describes the document.
+
+<b>Expected results</b>
+* #1 and #2 are true.
+
+<i>Verify that the page/view has no available mechanism to define a title</i>
+
+<b>Procedure</b>
+
+For each page/view where no title element is present:
+1. Determine whether the current page/view allows setting the HTML document `title` element.
+2. If the page/view is rendered within the current document context (e.g. modal dialog, popup, etc.) and does not provide a mechanism to set a document-level `title`, the exception applies.
+
+<b>Expected results</b>
+* #1 and #2 are true.
+:::


### PR DESCRIPTION
Based on the results of the [April 26 survey](https://www.w3.org/wbs/35422/wcag3-provision-survey-02/results/), 
this PR updates the "Page/view title available" provision, including the ACT Rules and corrects a typo in the provision.

An issue has been opened based on survey feedback to be addressed in future iterations: https://github.com/w3c/wcag3/issues/694

@netlify /guidelines/#user-orientation