### PR TITLE
Exploring presentation of links to informative materials, toggletip edition

### DIFF
--- a/src/components/guidelines/Guidelines.astro
+++ b/src/components/guidelines/Guidelines.astro
@@ -24,13 +24,13 @@ import EntryText from "./EntryText.astro";
             </button>
           </h4>
           <dialog popover id={`popover-${guideline.id}`}>
-          <h3>{computeGuidelineTitle(guideline)}</h3>
-          <p>More information about this guideline is available:</p>
-          <ul>
-            <li><a href={`${import.meta.env.BASE_URL}${informativeSlug}/${guideline.id}/`}>{computeGuidelineTitle(guideline)}</a></li>
-          </ul>
-          <button autofocus type="button" popovertarget={`popover-${guideline.id}`} popovertargetaction="hide">Close</button>
-        </dialog>
+            <h3>{computeGuidelineTitle(guideline)}</h3>
+            <p>More information about this guideline is available:</p>
+            <ul>
+              <li><a href={`${import.meta.env.BASE_URL}${informativeSlug}/${guideline.id}/`}>{computeGuidelineTitle(guideline)}</a></li>
+            </ul>
+            <button autofocus type="button" popovertarget={`popover-${guideline.id}`} popovertargetaction="hide">Close</button>
+          </dialog>
           <EntryText entry={guideline} />
           {guideline.data.provisions.map((provision) => (
             <section
@@ -55,7 +55,6 @@ import EntryText from "./EntryText.astro";
                   <li><a href="#">Open issues</a></li>
                 </ul>
                 <button autofocus type="button" popovertarget={`popover-${provision.id}`} popovertargetaction="hide">Close</button>
-              
               </dialog>
               <EntryText entry={provision} />
             </section>

--- a/src/components/guidelines/Guidelines.astro
+++ b/src/components/guidelines/Guidelines.astro
@@ -17,12 +17,20 @@ import EntryText from "./EntryText.astro";
       {group.data.guidelines.map((guideline) => (
         <section class="guideline" data-status={guideline.data.status || undefined}>
           <h4>{computeGuidelineTitle(guideline)}
-            <span class="infolink"><a href={`${import.meta.env.BASE_URL}${informativeSlug}/${guideline.id}/`}><svg aria-hidden="true" class="i-info">
-              <use xlink:href="img/icons.svg#i-info" />
+            <button  popovertarget={`popover-${guideline.id}`} class="infobutton" aria-label={`More about ${computeGuidelineTitle(guideline)}`}>
+              <svg aria-hidden="true" class="i-info">
+                <use xlink:href="img/icons.svg#i-info" />
               </svg>
-              <span>About {computeGuidelineTitle(guideline)}</span>
-            </a></span>
+            </button>
           </h4>
+          <dialog popover id={`popover-${guideline.id}`}>
+          <h3>{computeGuidelineTitle(guideline)}</h3>
+          <p>More information about this guideline is available:</p>
+          <ul>
+            <li><a href={`${import.meta.env.BASE_URL}${informativeSlug}/${guideline.id}/`}>{computeGuidelineTitle(guideline)}</a></li>
+          </ul>
+          <button autofocus type="button" popovertarget={`popover-${guideline.id}`} popovertargetaction="hide">Close</button>
+        </dialog>
           <EntryText entry={guideline} />
           {guideline.data.provisions.map((provision) => (
             <section
@@ -32,12 +40,21 @@ import EntryText from "./EntryText.astro";
               data-skip={provision.skippable}
             >
               <h5>{computeGuidelineTitle(provision)}
-                <span class="infolink"><a href={`${import.meta.env.BASE_URL}${informativeSlug}/${provision.id}/`}><svg aria-hidden="true" class="i-info">
-                  <use xlink:href="img/icons.svg#i-info" />
+                <button popovertarget={`popover-${provision.id}`} class="infobutton" aria-label={`More about ${computeGuidelineTitle(provision)}`}>
+                  <svg aria-hidden="true" class="i-info">
+                    <use xlink:href="img/icons.svg#i-info" />
                   </svg>
-                  <span>Understanding {computeGuidelineTitle(guideline)}</span>
-                </a></span>
+                </button>
               </h5>
+              <dialog popover id={`popover-${provision.id}`}>
+                <h3>{computeGuidelineTitle(provision)}</h3>
+                <p>More information about this provision is available:</p>
+                <ul>
+                  <li><a href={`${import.meta.env.BASE_URL}${informativeSlug}/${provision.id}/`}>{computeGuidelineTitle(provision)}</a></li>
+                </ul>
+                <button autofocus type="button" popovertarget={`popover-${provision.id}`} popovertargetaction="hide">Close</button>
+              
+              </dialog>
               <EntryText entry={provision} />
             </section>
           ))}

--- a/src/components/guidelines/Guidelines.astro
+++ b/src/components/guidelines/Guidelines.astro
@@ -50,7 +50,9 @@ import EntryText from "./EntryText.astro";
                 <h3>{computeGuidelineTitle(provision)}</h3>
                 <p>More information about this provision is available:</p>
                 <ul>
-                  <li><a href={`${import.meta.env.BASE_URL}${informativeSlug}/${provision.id}/`}>{computeGuidelineTitle(provision)}</a></li>
+                  <li><a href={`${import.meta.env.BASE_URL}${informativeSlug}/${provision.id}/`}>Documentation for “{computeGuidelineTitle(provision)}”</a></li>
+                  <li><a href="#">Tests</a></li>
+                  <li><a href="#">Open issues</a></li>
                 </ul>
                 <button autofocus type="button" popovertarget={`popover-${provision.id}`} popovertargetaction="hide">Close</button>
               

--- a/src/components/respec/GuidelinesRespec.astro
+++ b/src/components/respec/GuidelinesRespec.astro
@@ -247,8 +247,8 @@ import GuidelinesRespecDev from "./GuidelinesRespecDev.astro";
     });
   }
 
-  function removeTOCInfoLink() {
-    document.querySelectorAll('.toc .infolink').forEach(function (node) {
+  function removeTOCInfoButton() {
+    document.querySelectorAll('.toc .infobutton').forEach(function (node) {
       node.remove();
     });
   }
@@ -510,7 +510,7 @@ import GuidelinesRespecDev from "./GuidelinesRespecDev.astro";
       adjustNormativity,
       removeDraftMethodLinks,
       removeRequirementNum,
-      removeTOCInfoLink,
+      removeTOCInfoButton,
       addGuidelineText,
       addRequirementType,
       addStatusMarkers,

--- a/src/styles/guidelines.css
+++ b/src/styles/guidelines.css
@@ -182,40 +182,39 @@ section {
 	padding: 1em;
 	position: relative;
 	overflow: visible;
-    transition: opacity 0.2s, transform 0.2s, display 0s allow-discrete;
-	
+	transition: opacity 0.2s, transform 0.2s, display 0s allow-discrete;
+
 	opacity: 0;
-	/* transform: translateY(-1rem); */
-	
-	  &:popover-open {
+
+	&:popover-open {
 		opacity: 1;
 		transform: none;
 	
 		@starting-style {
-		  & {
-			opacity: 0;
-			transform: translateY(-1rem);
-		  }
+			& {
+				opacity: 0;
+				transform: translateY(-1rem);
+			}
 		}
-	  }
- 	}
-	[popover] > :first-child,
-	#guidelines [popover] .header-wrapper :first-child {
-		margin-top: 0;
 	}
-	[popover] a[href] {
-		color: white;
-	}
-	[popover]::after {
-		content: '';
-		border-left: 1em solid transparent;
-		border-right: 1em solid transparent;
-		border-top: 1em solid rgba(0, 0, 0, 0.75);
-		position: absolute;
-		top: 100%;
-		left: 50%;
-		transform: translate(-50%);
-	}
+}
+[popover] > :first-child,
+#guidelines [popover] .header-wrapper :first-child {
+	margin-top: 0;
+}
+[popover] a[href] {
+	color: white;
+}
+[popover]::after {
+	content: '';
+	border-left: 1em solid transparent;
+	border-right: 1em solid transparent;
+	border-top: 1em solid rgba(0, 0, 0, 0.75);
+	position: absolute;
+	top: 100%;
+	left: 50%;
+	transform: translate(-50%);
+}
 
 .doclinks {
 	margin-left: 0.2em;

--- a/src/styles/guidelines.css
+++ b/src/styles/guidelines.css
@@ -167,6 +167,9 @@ section {
 	font-size: 1em;
 	cursor: pointer;
 }
+	.infobutton:hover {
+		color: inherit;
+	}
 
 [popover] {
 	margin: 0;
@@ -179,7 +182,23 @@ section {
 	padding: 1em;
 	position: relative;
 	overflow: visible;
-}
+    transition: opacity 0.2s, transform 0.2s, display 0s allow-discrete;
+	
+	opacity: 0;
+	/* transform: translateY(-1rem); */
+	
+	  &:popover-open {
+		opacity: 1;
+		transform: none;
+	
+		@starting-style {
+		  & {
+			opacity: 0;
+			transform: translateY(-1rem);
+		  }
+		}
+	  }
+ 	}
 	[popover] > :first-child,
 	#guidelines [popover] .header-wrapper :first-child {
 		margin-top: 0;

--- a/src/styles/guidelines.css
+++ b/src/styles/guidelines.css
@@ -159,19 +159,44 @@ section {
 		grid-template-columns: 2fr 1fr;
 	}
 }
-
-.infolink svg {
-	vertical-align: middle;
+.infobutton {
+	color: #034575;
+	color: var(--a-normal-text);
+	border: 0;
+	background: transparent;
+	font-size: 1em;
+	cursor: pointer;
 }
 
-.infolink span {
-	display: none;
-	font-size: 80%
+[popover] {
+	margin: 0;
+	inset: auto;
+	bottom: calc(anchor(top) + 20px);
+	justify-self: anchor-center;
+	background-color: rgba(0, 0, 0, 0.75);
+	color: white;
+	border: 0;
+	padding: 1em;
+	position: relative;
+	overflow: visible;
 }
-
-.infolink a:hover span, .infolink a:focus span {
-	display: inline;
-}
+	[popover] > :first-child,
+	#guidelines [popover] .header-wrapper :first-child {
+		margin-top: 0;
+	}
+	[popover] a[href] {
+		color: white;
+	}
+	[popover]::after {
+		content: '';
+		border-left: 1em solid transparent;
+		border-right: 1em solid transparent;
+		border-top: 1em solid rgba(0, 0, 0, 0.75);
+		position: absolute;
+		top: 100%;
+		left: 50%;
+		transform: translate(-50%);
+	}
 
 .doclinks {
 	margin-left: 0.2em;


### PR DESCRIPTION
This builds on #685 and gives each guideline and provision a toggletip for 'info', that can contain related content on requests.

<img width="1280" height="720" alt="short animation showing a requirement where the i icon is clicked and a popover opens above it, subtly animates; it is closed and then keyboard is used to open" src="https://github.com/user-attachments/assets/d40d5235-aa11-4292-b257-d553d19fc0a5" />


> [!CAUTION]
> **Best previewed in recent Chrome or Edge; demo uses modern CSS that will be available across all browsers this year; we can polyfill / add fallbacks to make it work for older browsers too**

Benefits: 

- one tab stop for however much related content we want to link out to 
- it floats so does not cause reflow
- (I'm hoping) having it available on request is good rather than always; not in the way for people who don't need it, easy to find for people who do 

This specific implementation: 

- uses HTML/CSS only
- has accessibility semantics, keyboard behaviour (ESC for close)
- needs explicit open/close, avoiding issues of having to make hover behaviour work on touch devices (this 'just' works with touch)
- can be polished eg to automatically make it flip in right direction depending on available space, and on smaller screens

Open questions: 

- What actual content to add… is it just a list of links? is a heading or introductory text ('this info is available: ') helpful?