### PR TITLE
Upgrade actions to recent versions relying on Node v24

### DIFF
--- a/.github/workflows/cspell.yml
+++ b/.github/workflows/cspell.yml
@@ -8,5 +8,5 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: streetsidesoftware/cspell-action@v7
+      - uses: actions/checkout@v6
+      - uses: streetsidesoftware/cspell-action@v8

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: npm
           node-version-file: .nvmrc
@@ -41,7 +41,7 @@ jobs:
           curl https://www.w3.org/publications/spec-generator/?type=respec -F file=@explainer.tar -o dist/client/explainer/index.html -f --retry 3
           curl https://www.w3.org/publications/spec-generator/?type=respec -F file=@requirements.tar -o dist/client/requirements/index.html -f --retry 3
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist/client
 
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
This resolves warnings about actions that rely on Node v20.

I test-ran all of the workflows on my fork with this branch to confirm they all still run as expected.