### PR TITLE
Error handling user needs statements review

### DIFF
--- a/informative/guidelines/error-handling/correct-errors.md
+++ b/informative/guidelines/error-handling/correct-errors.md
@@ -1,23 +1,23 @@
 ## User needs
 
-* [TODO] User needs an error message when an error occurs so they know something went wrong.
-* [TODO] User needs form to notify them when it changes values so they can review and verify accuracy of any changes to data.
-* [TODO] User needs a visual notification so they know something went wrong.
-* [TODO] User needs an error message that displays in the viewport so they can identify the error message and access the content with screen magnification.
-* [TODO] User needs a prominent high-contrast error message so they can identify the error message.
-* [TODO] User needs an error message that is identifiable without symbols so they can identify the error message.
-* [TODO] User needs an error message that is identifiable without text so they can identify the error message.
-* [TODO] User needs an error message with a consistent interface so they know they are interacting with the same digital product.
-* [TODO] User needs an error message describing the error so they know what went wrong.
-* [TODO] User needs an error message describing the remedy so they know how to recover from the error.
-* [TODO] User needs an error message that displays at the source of the error so they can access the remedy instructions while focused on the source of the error.
-* [TODO] User needs an error message that is programmatically associated with the source of the error so they can access the remedy instructions while focused on the source of the error.
-* [TODO] User needs an error message that is linked to the error source so they can readily move focus to invalid inputs to correct them.
-* [TODO] User needs reassuring remedy instructions so they can have confidence they can resolve the error.
-* [TODO] User needs a visual indicator of the error source so they know which component is the source of the error.
-* [TODO] User needs an error message that is provided when the error occurs so they can readily refocus on the source of the error.
-* [TODO] User needs an error message that persists until the error is remedied so they can access the remedy instructions for as long as it takes to address the error.
-* [TODO] User needs an error message that is focused when the page reloads so they know there was an error.
-* [TODO] I need to be able to recover from making mistakes.
-* [TODO] Error recovery should be simple, and take you to a human operator. Error response should not throw the user off the line or send them to a more complex menu.
-* * [TODO] When I enter data or use a control, I receive feedback that I did it successfully or receive an error notification I can understand.
+* As a person who is blind or has low vision, or with a cognitive or learning disability, I need to know when an error has occurred so that I understand something went wrong.
+* As a person who is blind or has low vision, or with a cognitive or learning disability, I need to know when form field data  changes so that I can review it and confirm it is correct.
+* As a person who is deaf or hard of hearing, I need error information to be available visually so that I understand when something has gone wrong.
+* As a person with low vision who uses screen magnification, I need to be able to easily find and access information about an error so that I can understand and fix it.
+* As a person with low vision, I need information about errors to have sufficient contrast so that I can easily see the message.
+* As a person with a cognitive or learning disability, I need error information to be understandable without relying on symbols alone so that I can identify when something has gone wrong.
+* As a person with a cognitive or reading disability, I need to be able to recognize when an error has occurred without relying on text so that I understand something went wrong.
+* As a person with a cognitive disability, I need error-related information and interactions to be presented consistently so that I know I’m interacting with the same digital product.
+* As a person with a cognitive or learning disability, I need errors to be explained clearly and simply so that I understand what went wrong.
+* As a person with a cognitive or learning disability, I need to understand how to recover from an error so that I can complete my task successfully.
+* As a person with a cognitive or learning disability, I need access to recovery instructions while correcting an error so that I can fix it without losing my place.
+* As a person who is blind or who has a motor disability, I need recovery instructions to be programmatically associated with the source of the error so that I can access the instructions while focused on the source of the error.
+* As a person who is blind or who has a motor disability, I need to be able to access the source of an error while interacting with an error message so that I can easily move focus to invalid inputs and correct them.
+* As a person with a cognitive or learning disability, I need clear guidance that gives me confidence I can correct an error.
+* As a person with a cognitive or learning disability, I need to be able to visually identify which input or component contains an error so that I can correct it.
+* As a person with a cognitive or learning disability, I need timely information about errors so that I can address them while my attention is still on the relevant task.
+* As a person with a cognitive or learning disability, I need error information to remain available while I correct the problem so that I do not have to rely on my memory.
+* As a person who is blind, I need to be made aware of errors after a page reload so that I know my action was unsuccessful.
+* As a person who is blind or has low vision, or with a cognitive, learning, or motor disability, I need to be able to recover from mistakes.
+* As a person with a cognitive or learning disability, I need to be able to easily get help from another person when I cannot recover from an error on my own.
+* As a person with a cognitive or learning disability, when I enter data or use a control, I need to understand whether my action was successful or unsuccessful.

--- a/informative/guidelines/error-handling/prevent-errors.md
+++ b/informative/guidelines/error-handling/prevent-errors.md
@@ -1,4 +1,5 @@
 ## User needs
 
-* [TODO] I need help avoiding mistakes.
-* [TODO] When I enter data or use a control, I receive feedback that I did it successfully or receive an error notification I can understand.
+* As a person with a cognitive or learning disability, I need help avoiding mistakes. 
+* As a person with a cognitive or learning disability, when I enter data or use a control, I need to understand whether my action was successful or unsuccessful.
+* As a person who is blind or has low vision, or a cognitive or learning disability, I need to know when form field data changes so that I can review it and confirm it's correct.


### PR DESCRIPTION
**List of guidelines that have been updated for review:**

- [x]  Guideline 2.5.1 Correct errors
- [x]  Guideline 2.5.2 Prevent errors

**Subgroup to review:**

- [ ] Errors, task completion and help 

**Statement checklist:**

- [ ] Statement is not too broad
- [ ] User need is clear
- [ ] User group(s) identified for the need
- [ ] Statement contains no solution
- [ ] Statement uses the structure of a user needs statement
- [ ] Should only some of the statements have a 'so that' clause?
- [ ] Wording is in plain language
- [ ] Statement is under the right guideline
- [ ] Are any user needs missing for this guideline?