### PR TITLE
Fix typecheck errors (mostly affecting dev pages)

### DIFF
--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -164,7 +164,7 @@ export const server = {
           })
         );
         // Update title and issueLabel in groups/{group}/{guideline}/{provision}.md if applicable
-        await updateYamlFrontmatter<"requirements">(join(normativeBase, `${id}.md`), (data) => {
+        await updateYamlFrontmatter<"provisions">(join(normativeBase, `${id}.md`), (data) => {
           const updatedData = setOrUnsetTitle(data);
           if (!updatedData.issueLabel) updatedData.issueLabel = computeGuidelineTitle(entry);
           return updatedData;

--- a/src/lib/dev.ts
+++ b/src/lib/dev.ts
@@ -1,5 +1,5 @@
 /** @file Server-side utilities related to dev-mode-only pages */
 
 /** Collections that have actions exposed via the dev server */
-export const devManageableCollections = ["groups", "guidelines", "requirements"] as const;
+export const devManageableCollections = ["groups", "guidelines", "provisions"] as const;
 export type DevManageableCollection = (typeof devManageableCollections)[number];

--- a/src/lib/guidelines.ts
+++ b/src/lib/guidelines.ts
@@ -136,7 +136,7 @@ export const computeGuidelineTitle = (entry: EntryWithTitle) =>
   computeTitle(entry, { capitalize: true });
 
 /** Returns a provision's issue label as it should be formatted in the GitHub repository. */
-export const computeProvisionIssueLabel = (entry: CollectionEntry<"requirements">) =>
+export const computeProvisionIssueLabel = (entry: CollectionEntry<"provisions">) =>
   `P - ${capitalize(entry.data.issueLabel) || computeGuidelineTitle(entry).replace(/,/g, "")}`;
 
 /**

--- a/src/pages/dev/issue-labels.astro
+++ b/src/pages/dev/issue-labels.astro
@@ -4,7 +4,7 @@ import { computeProvisionIssueLabel } from "@/lib/guidelines";
 import { getCollection } from "astro:content";
 
 const provisionsWithIssueLabel = await getCollection(
-  "requirements",
+  "provisions",
   ({ data }) => !!data.issueLabel
 );
 ---

--- a/src/pages/dev/rename/[collection].astro
+++ b/src/pages/dev/rename/[collection].astro
@@ -21,8 +21,8 @@ const optionsByCollection: Record<
 > = {
   groups: groupsTree.map(computeOption),
   guidelines: groupsTree.flatMap((group) => group.data.guidelines.map(computeOption)),
-  requirements: groupsTree.flatMap((group) =>
-    group.data.guidelines.flatMap((guideline) => guideline.data.requirements.map(computeOption))
+  provisions: groupsTree.flatMap((group) =>
+    group.data.guidelines.flatMap((guideline) => guideline.data.provisions.map(computeOption))
   ),
 };
 
@@ -41,7 +41,7 @@ if (!options) return Astro.redirect("/dev/"); // This will only happen on invali
       <li>File and folder names for both normative and informative content</li>
       <li>The relevant children entry within the parent entry</li>
       {
-        collection === "requirements" && (
+        collection === "provisions" && (
           <>
             <li>
               Addition of <code>issueLabel</code> to avoid breaking links in the current Working


### PR DESCRIPTION
This fixes typecheck errors overlooked in #676 which did not block the build and mainly affects dev-mode pages. (Apparently I did not in fact replace all usages of `requirements` with `provisions`.)

#729 is a separate PR to add a workflow to prevent this sort of thing from sneaking by again.