### PR TITLE
Informative docs: Don't list or render pages for empty entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "check": "astro check",
     "cspell": "cspell .",
     "preview": "astro preview",
-    "start": "astro dev",
+    "start": "astro dev --force",
     "sync": "astro sync --force",
     "astro": "astro"
   },

--- a/src/lib/informative.ts
+++ b/src/lib/informative.ts
@@ -2,11 +2,13 @@ import type { GetStaticPaths } from "astro";
 import {
   getCollection,
   getEntry,
+  render,
   type CollectionEntry,
   type CollectionKey,
   type RenderedContent,
 } from "astro:content";
 import { load } from "cheerio";
+import memoize from "lodash/memoize";
 import noop from "lodash/noop";
 import sortBy from "lodash/sortBy";
 import pluralize from "pluralize";
@@ -55,9 +57,7 @@ export async function resolveInformativeProvision(id: string) {
   const normativeProvision = await getEntry("provisions", id);
   if (!normativeProvision) throw new Error(`Normative data not found for provision: ${id}`);
 
-  const informativeProvision = await silenceWarnings(() =>
-    getEntry("informativeProvisions", id)
-  );
+  const informativeProvision = await silenceWarnings(() => getEntry("informativeProvisions", id));
   if (!informativeProvision) return null;
   return {
     ...informativeProvision,
@@ -73,7 +73,7 @@ export type InformativeProvision = NonNullable<
  * Returns a list of IDs of groups containing informative content,
  * in the same order presented in the normative guidelines document.
  */
-export async function resolveInformativeGroups() {
+export const resolveInformativeGroups = memoize(async () => {
   const groups: (CollectionEntry<"groups"> & { title: string })[] = [];
   const populatedGroupIds = (await getCollection("informativeGuidelines")).reduce((set, entry) => {
     set.add(entry.id.slice(0, entry.id.indexOf("/")));
@@ -84,48 +84,60 @@ export async function resolveInformativeGroups() {
     if (!populatedGroupIds.has(id)) continue;
     const group = await getEntry("groups", id);
     if (!group) throw new Error(`Unresolvable group ID: ${id}`);
-    groups.push({
-      ...group,
-      title: computeGuidelineTitle(group),
-    });
+
+    // Only include groups that have children with content
+    if ((await resolveInformativeGuidelines(id)).length)
+      groups.push({
+        ...group,
+        title: computeGuidelineTitle(group),
+      });
   }
   return groups;
-}
+});
 
 /**
  * Assembles data for informative documentation of guidelines under the specified group,
  * including relevant details from normative data e.g. child order and title overrides.
  */
-export async function resolveInformativeGuidelines(groupId: string) {
+export const resolveInformativeGuidelines = memoize(async (groupId: string) => {
   const group = await getEntry("groups", groupId);
   if (!group) throw new Error(`Normative data not found for group: ${groupId}`);
 
   const guidelines: InformativeGuideline[] = [];
   for (const guidelineSlug of group.data.children) {
     const informativeGuideline = await resolveInformativeGuideline(`${groupId}/${guidelineSlug}`);
-    if (informativeGuideline) guidelines.push(informativeGuideline);
+    if (informativeGuideline) {
+      // Only include guidelines with content, or that have child provisions with content
+      const { remarkPluginFrontmatter } = await render(informativeGuideline);
+      if (
+        !remarkPluginFrontmatter.isEmpty ||
+        (await resolveInformativeProvisions(informativeGuideline.id)).length
+      )
+        guidelines.push(informativeGuideline);
+    }
   }
   return guidelines;
-}
+});
 
 /**
  * Assembles data for informative documentation of provisions under the specified guideline,
  * including relevant details from normative data e.g. child order and title overrides.
  */
-export async function resolveInformativeProvisions(guidelineId: string) {
+export const resolveInformativeProvisions = memoize(async (guidelineId: string) => {
   const normativeGuideline = await getEntry("guidelines", guidelineId);
   if (!normativeGuideline)
     throw new Error(`Normative data not found for guideline: ${guidelineId}`);
 
   const provisions: InformativeProvision[] = [];
   for (const provisionSlug of normativeGuideline.data.children) {
-    const informativeEntry = await resolveInformativeProvision(
-      `${guidelineId}/${provisionSlug}`
-    );
-    if (informativeEntry) provisions.push(informativeEntry);
+    const informativeEntry = await resolveInformativeProvision(`${guidelineId}/${provisionSlug}`);
+    if (informativeEntry) {
+      const { remarkPluginFrontmatter } = await render(informativeEntry);
+      if (!remarkPluginFrontmatter.isEmpty) provisions.push(informativeEntry);
+    }
   }
   return provisions;
-}
+});
 
 /** Formats normative content for inclusion within an informative page. */
 export function formatNormativeContent(rendered: RenderedContent) {

--- a/src/lib/markdown/informative.ts
+++ b/src/lib/markdown/informative.ts
@@ -15,6 +15,7 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
     !tree.children.length ||
     (tree.children.length === 1 && tree.children[0].type === "heading")
   ) {
+    file.data.astro!.frontmatter!.isEmpty = true;
     tree.children.push({
       type: "containerDirective",
       name: "ednote",


### PR DESCRIPTION
**Note:** I am initially opening this as a draft, as it currently results in nothing being listed on the informative page; I suspect we'd want to wait until some informative content is merged before previewing and merging this.

**Note 2:** This might be rendered somewhat unnecessary by #776, which adds content for many provisions aside from assertions

This enhances the functions responsible for listing informative groups/guidelines/provisions to filter out entries that would not have any content to show.

What this means:

- Provisions are only listed if they have content (i.e. they would not display the "this content needs to be written" Editor's Note)
- Guidelines are only listed if they have content or contain at least one child that passes filtering
- Groups are only listed if they contain at least one guideline that passes filtering

One thing worth noting is that this filtering also applies at the guideline level, to the "Provisions under this guideline" heading, which we might want to rephrase or add some explanation to the effect of only listing provisions that specifically have informative guidance.

This operates by programmatically adding an `isEmpty` flag to frontmatter during Markdown processing (at the same time that the "This content needs to be written" editor's note is output). This flag is then checked by calling `render` during the informative data lookup process. These informative lookups are now memoized to avoid expensive and repetitive processing, between the `render` calls and the pre-scanning of children to determine parent visibility.

Note: Kevin suggested we might deprioritize this for this cycle in favor of the effects of #731 being more omnipresent, to solicit feedback on that

## TODOs

- [ ] Consistently filter links in normative document (i.e. don't link to informative pages with no content)
- [ ] Don't filter out informative pages with "no content" if they do possess child pages (ACT rules, methods, best practices)