### PR TITLE
Build: Move "Applies when" to top; enforce containing a list

### DIFF
--- a/guidelines/groups/text-and-wording/clear-language/non-literal-language-explained.md
+++ b/guidelines/groups/text-and-wording/clear-language/non-literal-language-explained.md
@@ -7,12 +7,11 @@ title: Non-literal language explained
 Explanations or unambiguous alternatives are available in :term[text content] for :term[non-literal language], such as idioms and metaphors.
 
 :::except-when
-<p>text content is:</p>
-
-* poetic,
-* scriptural,
-* artistic, or
-* expressive rather than informational. 
+* text content is:
+  * poetic,
+  * scriptural,
+  * artistic, or
+  * expressive rather than informational.
 :::
 
 :::ednote

--- a/src/lib/markdown/guidelines.ts
+++ b/src/lib/markdown/guidelines.ts
@@ -31,6 +31,12 @@ function expectGuidelineFileType(
     file.fail(`${directiveName} expected at ${expectedType} level but found at ${type} level`);
 }
 
+/** Fails validation if the given node does not exclusively contain an unordered list. */
+function expectDirectiveWithUnorderedList(file: VFile, node: ContainerDirective) {
+  if (node.children.length !== 1 || node.children[0].type !== "list" || node.children[0].ordered)
+    file.fail(`${node.name} is expected to contain only an unordered list`);
+}
+
 const isTermFile = (file: VFile) => file.dirname?.startsWith(join(file.cwd, "guidelines", "terms"));
 
 /** Adds standard editor's note to terms with empty content. */
@@ -50,28 +56,13 @@ const addEmptyTermNote: RemarkPlugin = () => (tree, file) => {
 };
 
 /**
- * Prepends a <b> element containing the given label.
- * If the given node contains a single paragraph, it prepends inline;
- * otherwise, it prepends a preceding paragraph before the node.
+ * Prepends a paragraph before the given node, containing the given text in bold (`<b>`).
  **/
 function prependBoldText(node: ContainerDirective, label: string) {
-  const firstChild = node.children[0];
-  if (firstChild.type === "paragraph") {
-    if ("value" in firstChild.children[0]) {
-      firstChild.children[0].value = firstChild.children[0].value.replace(/[a-z]/i, (str) =>
-        str.toLowerCase()
-      );
-    }
-    firstChild.children.unshift({
-      type: "html",
-      value: `<b>${label}</b> `,
-    });
-  } else {
-    node.children.unshift({
-      type: "html",
-      value: `<p><b>${label}</b></p>`,
-    });
-  }
+  node.children.unshift({
+    type: "html",
+    value: `<p><b>${label}</b></p>`,
+  });
 }
 
 const customDirectives: RemarkPlugin = () => (tree, file) => {
@@ -112,13 +103,20 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
         });
       } else if (isGuideline && node.name === "applies-when") {
         expectGuidelineFileType(file, "provision", ":::applies-when");
+        expectDirectiveWithUnorderedList(file, node);
 
         prependBoldText(node, "Applies when");
         if (parent && typeof index !== "undefined") {
-          parent.children.splice(index!, 1, ...node.children);
+          parent.children = [
+            // Place applies-when content first, then discard container node
+            ...node.children,
+            ...parent.children.slice(0, index),
+            ...parent.children.slice(index + 1),
+          ];
         }
       } else if (isGuideline && node.name === "except-when") {
         expectGuidelineFileType(file, "provision", ":::except-when");
+        expectDirectiveWithUnorderedList(file, node);
 
         if (
           parent &&
@@ -132,7 +130,7 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
 
         prependBoldText(node, "Except when");
         if (parent && typeof index !== "undefined")
-          parent.children.splice(index!, 1, ...node.children);
+          parent.children.splice(index, 1, ...node.children);
       }
     } else if (node.type === "leafDirective") {
       if (isGuideline && node.name === "assertion-required") {


### PR DESCRIPTION
**Note:** This PR is intentionally sequenced on top of #731 which was agreed upon during last week's Editors meeting, as the simplified DOM/styling in that PR makes this far more reasonable to implement.

The main change this PR implements is to move the content of the `:::applies-when` directive to the top of the provision. This should eventually probably be done directly within each content file, but for the time being, this accomplishes the change without needing to change a bunch of files and risk conflicts with other PRs.

Along with that change, this PR implements some simplifications:

- Since we already aligned on making all Applies when and Except when content consist of a list, this PR removes some code that is no longer needed under that assumption, and enforces the pattern
- Enforcing the pattern found one `:::except-when` clause that did not satisfy it; I changed that to match other similar cases
- Removed a `!` that was unnecessary due to a preceding check for defined value