### PR TITLE
Removed guardrail languages + other changes to blocks-of-text-a…

### DIFF
--- a/guidelines/groups/text-and-wording/text-appearance/blocks-of-text-adjustable.md
+++ b/guidelines/groups/text-and-wording/text-appearance/blocks-of-text-adjustable.md
@@ -4,7 +4,12 @@ status: developing
 type: foundational
 ---
 
-The presentation of :term[blocks of text] can be adjusted, without loss of content or functionality, to meet the corresponding values for the :term[content]'s language, or where that language is not listed in the table, for the language listed with the most similar orthography.
+The presentation of :term[blocks of text] can be adjusted, without loss of content or functionality, to meet the @@[X values, to be determined] for:
+* Inline margin
+* Block margin
+* Line length
+* Line height
+* Justification
 
 :::note
 The requirement is that the text is manipulable and the style attributes can be overridden.
@@ -15,66 +20,7 @@ The requirement is that the text is manipulable and the style attributes can be 
 :::
 
 :::ednote
-The metrics in the following table are still to be determined; the current content is an example.
-:::
-
-<table class="data">
- <thead>
-   <tr>
-     <th scope="col">Characteristic</th>
-     <th scope="col">Arabic</th>
-     <th scope="col">Chinese</th>
-     <th scope="col">English</th>
-     <th scope="col">Hindi</th>
-     <th scope="col">Russian</th>
-   </tr>
-   </thead>
-   <tbody>
-     <tr>
-       <th scope="row">Inline margin</th>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-     </tr>
-    <tr>
-       <th scope="row">Block Margin</th>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-     </tr>  
-     <tr>
-       <th scope="row">Line length</th>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-     </tr>
-     <tr>
-       <th scope="row">Line height</th>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-     </tr>
-     <tr>
-       <th scope="row">Justification</th>
-       <td></td>
-       <td>Not applicable</td>
-       <td>Default inline start to Left aligned</td>
-       <td></td>
-       <td></td>
-     </tr>
-    </tbody>
-</table>
-
-:::note
-[Blocks of text readable (minimum)](#blocks-of-text-readable-minimum) and [Text style readable (minimum)](#text-style-readable-minimum) are based on common usage, and their adjustable and enhanced counterparts are based on readability research. We need more readability research in these languages.
+If you are aware of research in this area, especially involving non-Latin scripts, please email public-agwg-comments@w3.org.
 :::
 
 :::tests
@@ -82,7 +28,7 @@ The metrics in the following table are still to be determined; the current conte
 <b>Procedure</b>
 
 For each block of text:
-1. Apply the highest level of change of each attribute from the table, for that language/script.
+1. Apply the highest level of change of each attribute specified in the provision.
 2. Check that the text is changed by the override. 
 
 <b>Expected results</b>

--- a/guidelines/groups/text-and-wording/text-appearance/blocks-of-text-adjustable.md
+++ b/guidelines/groups/text-and-wording/text-appearance/blocks-of-text-adjustable.md
@@ -4,7 +4,7 @@ status: developing
 type: foundational
 ---
 
-The presentation of :term[blocks of text] can be adjusted, without loss of content or functionality, to meet the @@[X values, to be determined] for:
+The presentation of :term[blocks of text] can be adjusted, without loss of content or functionality, to meet the @@ [values to be determined] for:
 * Inline margin
 * Block margin
 * Line length


### PR DESCRIPTION
…djustable.md

Similar to the changes made in a handful of Text Appearnace provisions:
* Replaced the mostly empty table about guardrail languages with a placeholder that now includes a bulleted list of what this provision will cover.
* Replaced all the notes/ed notes with one ed note to send research in this area, especially involving non-Latin scripts, to public-agwg-comments@w3.org
* Tweaked the test procedure so it doesn't refer to the now-removed table.