### PR TITLE
Removed guardrail languages + other changes to text-style-adjustable.md

### DIFF
--- a/guidelines/groups/text-and-wording/text-appearance/text-style-adjustable.md
+++ b/guidelines/groups/text-and-wording/text-appearance/text-style-adjustable.md
@@ -4,7 +4,12 @@ status: developing
 type: foundational
 ---
 
-The presentation of each of the following :term[text] style properties can be adjusted, without loss of content or functionality, to meet the corresponding values for the content’s language, or, if the language is not listed in the table, of the language listed with the most similar orthography.
+The presentation of :term[text] style properties can be adjusted, without loss of content or functionality, to meet the @@[X values, to be determined] for:
+* Font face
+* Font width
+* Text decoration
+* Capitalization
+* Automatic end-of-line hyphenation
 
 :::note
 The requirement is that the text is manipulable and the style attributes can be overridden.
@@ -15,80 +20,7 @@ The requirement is that the text is manipulable and the style attributes can be 
 :::
 
 :::ednote
-The metrics in the following table are still to be determined; the current content is an example.
-:::
-
-<table class="data">
- <thead>
-   <tr>
-     <th scope="col">Characteristic</th>
-     <th scope="col">Arabic</th>
-     <th scope="col">Chinese</th>
-     <th scope="col">English</th>
-     <th scope="col">Hindi</th>
-     <th scope="col">Russian</th>
-   </tr>
-   </thead>
-   <tbody>
-     <tr>
-       <th scope="row">Font face</th>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-     </tr>
-     <tr>
-       <th scope="row">Font width</th>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-     </tr>
-      <tr>
-       <th scope="row">Text decoration</th>
-       <td></td>
-       <td></td>
-       <td>
-        <ul>
-          <li>Most text is not bold, italicized, and/or underlined</li>
-          <li>Text is not bold and italicized at the same time</li>
-          <li>Underlines are only used for links</li>
-        </ul>
-       </td>
-       <td></td>
-       <td></td>
-     </tr>
-     <tr>
-       <th scope="row">Letter spacing</th>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-     </tr>
-     <tr>
-       <th scope="row">Capitalization</th>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-       <td></td>
-     </tr>
-    <tr>
-       <th scope="row">Automatic end-of-line hyphenation</th>
-       <td></td>
-       <td></td>
-       <td>Disabled</td>
-       <td></td>
-       <td></td>
-     </tr>
-    </tbody>
-</table>
-
-:::note
-[Blocks of text readable (minimum)](#blocks-of-text-readable-minimum) and [Text style readable (minimum)](#text-style-readable-minimum) are based on common usage, and their adjustable and enhanced counterparts are based on readability research. We need more readability research in these languages.
+If you are aware of research in this area, especially involving non-Latin scripts, please email public-agwg-comments@w3.org.
 :::
 
 :::tests
@@ -96,7 +28,7 @@ The metrics in the following table are still to be determined; the current conte
 <b>Procedure</b>
 
 For each block of text:
-1. Apply the highest level of change of each attribute from the table, for the closest language.
+1. Apply the highest level of change of each attribute specified in the provision.
 2. Check that the text is changed by the override. 
 
 <b>Expected results</b>

--- a/guidelines/groups/text-and-wording/text-appearance/text-style-adjustable.md
+++ b/guidelines/groups/text-and-wording/text-appearance/text-style-adjustable.md
@@ -5,7 +5,7 @@ type: foundational
 ---
 
 The presentation of :term[text] style properties can be adjusted, without loss of content or functionality, to meet the @@[X values, to be determined] for:
-* Font face
+* Typeface
 * Font width
 * Text decoration
 * Capitalization

--- a/guidelines/groups/text-and-wording/text-appearance/text-style-adjustable.md
+++ b/guidelines/groups/text-and-wording/text-appearance/text-style-adjustable.md
@@ -4,7 +4,7 @@ status: developing
 type: foundational
 ---
 
-The presentation of :term[text] style properties can be adjusted, without loss of content or functionality, to meet the @@[X values, to be determined] for:
+The presentation of :term[text] style properties can be adjusted, without loss of content or functionality, to meet the @@ [values to be determined] for:
 * Typeface
 * Font width
 * Text decoration


### PR DESCRIPTION
Similar to the changes in a bunch of Text Appearance provisions:
* Replaced the mostly empty table about guardrail languages with a placeholder that now includes a bulleted list of what this provision will cover.
* Replaced all the notes/ed notes with one ed note to send research in this area, especially involving non-Latin scripts, to public-agwg-comments@w3.org
* Tweaked the test procedure so it doesn't refer to the now-removed table.