### PR TITLE
Reflect WCAG_PUBLISH behavior in informative provision lists

### DIFF
--- a/src/lib/informative.ts
+++ b/src/lib/informative.ts
@@ -11,7 +11,7 @@ import noop from "lodash/noop";
 import sortBy from "lodash/sortBy";
 import pluralize from "pluralize";
 
-import { computeGuidelineTitle, computeTermTitle } from "./guidelines";
+import { computeGuidelineTitle, computeTermTitle, provisionSlugMap } from "./guidelines";
 
 /**
  * Wraps a function call to silence its console.warn calls,
@@ -117,6 +117,7 @@ export async function resolveInformativeProvisions(guidelineId: string) {
 
   const provisions: InformativeProvision[] = [];
   for (const provisionSlug of normativeGuideline.data.children) {
+    if (!provisionSlugMap[provisionSlug]) continue; // Inherit WCAG_SKIP_WIP behavior
     const informativeEntry = await resolveInformativeProvision(`${guidelineId}/${provisionSlug}`);
     if (informativeEntry) provisions.push(informativeEntry);
   }

--- a/src/lib/informative.ts
+++ b/src/lib/informative.ts
@@ -117,7 +117,7 @@ export async function resolveInformativeProvisions(guidelineId: string) {
 
   const provisions: InformativeProvision[] = [];
   for (const provisionSlug of normativeGuideline.data.children) {
-    if (!provisionSlugMap[provisionSlug]) continue; // Inherit WCAG_SKIP_WIP behavior
+    if (!provisionSlugMap[provisionSlug]) continue; // Inherit WCAG_PUBLISH behavior
     const informativeEntry = await resolveInformativeProvision(`${guidelineId}/${provisionSlug}`);
     if (informativeEntry) provisions.push(informativeEntry);
   }

--- a/src/pages/informative/[groupId]/[guidelineSlug]/index.astro
+++ b/src/pages/informative/[groupId]/[guidelineSlug]/index.astro
@@ -2,8 +2,8 @@
 import type { GetStaticPaths, GetStaticPathsResult } from "astro";
 
 import KeyTerms from "@/components/informative/KeyTerms.astro";
+import ProvisionLink from "@/components/informative/ProvisionLink.astro";
 import InformativeLayout from "@/layouts/InformativeLayout.astro";
-import { informativeSlug } from "@/lib/constants";
 import {
   formatNormativeContent,
   processKeyTerms,
@@ -54,9 +54,7 @@ const { html, terms } = processKeyTerms(
     {
       provisions.map((provision) => (
         <li>
-          <a href={`${import.meta.env.BASE_URL}${informativeSlug}/${provision.id}/`}>
-            {provision.title}
-          </a>
+          <ProvisionLink entry={provision} />
         </li>
       ))
     }

--- a/src/pages/informative/[groupId]/[guidelineSlug]/index.astro
+++ b/src/pages/informative/[groupId]/[guidelineSlug]/index.astro
@@ -50,14 +50,29 @@ const { html, terms } = processKeyTerms(
   <h2>Guideline</h2>
   <Fragment set:html={html} />
   <h2>Provisions under this guideline</h2>
-  <ul>
-    {
-      provisions.map((provision) => (
-        <li>
-          <ProvisionLink entry={provision} />
-        </li>
-      ))
-    }
-  </ul>
+  {
+    provisions.length ? (
+      <ul>
+        {provisions.map((provision) => (
+          <li>
+            <ProvisionLink entry={provision} />
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <div class="ednote">
+        <p>
+          Requirements and assertions for this guideline do not appear here because they have not
+          yet progressed beyond exploratory. See the{" "}
+          <a
+            href={`https://w3c.github.io/wcag3/informative/${groupId}/${guidelineSlug}/#provisions-under-this-guideline`}
+          >
+            Editor's Draft
+          </a>{" "}
+          for the complete list of potential requirements and assertions.
+        </p>
+      </div>
+    )
+  }
   <KeyTerms terms={terms} />
 </InformativeLayout>


### PR DESCRIPTION
This PR applies consistent filtering to lists of provisions under informative pages, to match the behavior of the TR document when the `WCAG_PUBLISH` environment variable is used.

In the case of individual guideline pages, it also replicates the note seen in the TR document in case of no provisions being rendered (but with a link to the same informative page under w3c.github.io/wcag3/informative/ rather than w3c.github.io/wcag3/guidelines). This can be seen in the Figure captions guideline under Images and media.

Note that the filtering will not be active on the PR preview since that doesn't set the environment variable that controls it; I have not added an option for client-side filtering the way we have in the TR document's ED, since in this case it would need to apply across multiple pages and I'm not sure that use case is as important for informative docs.