### PR TITLE
Rename WCAG_SKIP_WIP to WCAG_PUBLISH; include WAI base path adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,8 @@ built code is not expected to run properly when this is active!
 
 **Default:** Unset (set to any non-empty value to enable)
 
-### `WCAG_SKIP_WIP`
+### `WCAG_PUBLISH`
 
-When set, excludes provisions that have `needsAdditionalResearch` set to `true`,
+When set, updates base paths for informative pages to target the WAI site,
+and excludes provisions that have `needsAdditionalResearch` set to `true`,
 or that have `status` set to `placeholder` or `exploratory`.

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -13,14 +13,22 @@ import { fileURLToPath } from "url";
 
 import { remarkPlugins, rehypePlugins } from "./src/lib/markdown";
 
-const GH_REPO = process.env.GITHUB_REPOSITORY; // Only set during GitHub action
+/** Generates base path for informative URLs for PR previews vs. WAI publication vs. local dev. */
+function generateBase() {
+  if (process.env.GITHUB_REPOSITORY) {
+    const [, repo] = process.env.GITHUB_REPOSITORY.split("/");
+    return `/${repo}/`;
+  }
+  if (process.env.WCAG_PUBLISH) return "/WAI/WCAG3/";
+  return "/";
+}
 
 // https://astro.build/config
 export default defineConfig({
   adapter: node({
     mode: "standalone",
   }),
-  base: `${GH_REPO ? GH_REPO.slice(GH_REPO.indexOf("/")) : ""}/`,
+  base: generateBase(),
   devToolbar: { enabled: false },
   trailingSlash: "always",
   markdown: {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "check": "astro check",
     "cspell": "cspell .",
     "preview": "astro preview",
+    "publish-w3c": "WCAG_PUBLISH=1 astro build --force",
     "start": "astro dev",
     "sync": "astro sync --force",
     "astro": "astro"

--- a/src/lib/guidelines.ts
+++ b/src/lib/guidelines.ts
@@ -13,17 +13,14 @@ import { isDevOrPreview } from "./constants";
  */
 async function determineSkippableProvisions(groupId: string, guidelineSlug: string) {
   // Only populate when running a build that needs to skip at build time or client-side
-  if (!import.meta.env.WCAG_SKIP_WIP && !isDevOrPreview) return [];
+  if (!import.meta.env.WCAG_PUBLISH && !isDevOrPreview) return [];
 
   const guideline = await getEntry("guidelines", `${groupId}/${guidelineSlug}`);
   if (!guideline) throw new Error(`Unresolvable guideline ID: ${guidelineSlug}`);
 
   const skippableProvisions: string[] = [];
   for (const provisionSlug of guideline.data.children) {
-    const provision = await getEntry(
-      "provisions",
-      `${groupId}/${guidelineSlug}/${provisionSlug}`
-    );
+    const provision = await getEntry("provisions", `${groupId}/${guidelineSlug}/${provisionSlug}`);
     if (!provision) throw new Error(`Unresolvable provision ID: ${provisionSlug}`);
     if (
       provision.data.needsAdditionalResearch ||
@@ -73,7 +70,7 @@ export const groupsTree = await (async () => {
         guidelines[guideline.id] = guideline;
 
         const skippableChildren = await determineSkippableProvisions(groupId, guidelineSlug);
-        if (import.meta.env.WCAG_SKIP_WIP)
+        if (import.meta.env.WCAG_PUBLISH)
           // Filter children directly in case of build-time skip
           guideline.data.children = difference(guideline.data.children, skippableChildren);
 


### PR DESCRIPTION
This updates `astro.config.ts` to account for publishing informative docs under WAI space when also building the guidelines document for TR space.

This reuses the `WCAG_SKIP_WIP` flag which has already been used only for WD republications, but renames it to `WCAG_PUBLISH` to make its meaning a bit more tied to its purpose rather than what it does (since it now does multiple things).

I've also added a `publish-w3c` script analogous to the one in the w3c/wcag repo which runs the build with the environment variable set. (Unlike in w3c/wcag, this doesn't perform any copy operations to a CVS checkout, and I'm not sure if we feel that's necessary for this repo when it will involve copying one higher-level folder, as opposed to w3c/wcag where individual subfolders need to be copied.)

I had initially thought I would need to make more changes to support informative docs under WAI space being cross-linked from TR space, but since /TR and /WAI are both relative to w3.org, no fully-qualified URLs are necessary.