### PR TITLE
Dev: Fix link to dev page for renaming provisions

### DIFF
--- a/src/pages/dev/index.astro
+++ b/src/pages/dev/index.astro
@@ -7,7 +7,7 @@ import DevLayout from "@/layouts/DevLayout.astro";
   <ul>
     <li><a href="rename/groups/">Rename a group</a></li>
     <li><a href="rename/guidelines/">Rename a guideline</a></li>
-    <li><a href="rename/requirements/">Rename a provision</a></li>
+    <li><a href="rename/provisions/">Rename a provision</a></li>
   </ul>
   <h2>Publication Preparation</h2>
   <ul>


### PR DESCRIPTION
This is a follow-up to #676. When the content collection was renamed from `requirements` to `provisions`, that affected the functionality of the dev endpoints for renaming entries, because it relies on mapping the URL path to the collection name. The link to `/dev/rename/requirements` was simply redirecting back to `/dev/` because no `requirements` collection existed anymore.