### PR TITLE
Add README for informative files; remove unused user-needs directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# wcag3
-WCAG 3
+# WCAG 3
 
 There is a [presentation of the process the group](https://docs.google.com/presentation/d/14qG2f-ZkhFDqox_qmzqC5tCUt1xJaumkJS2l5GaD-3o/edit#slide=id.p) uses for addressing issues and updates.
 
@@ -31,6 +30,7 @@ All commands are run from the root of the project, from a terminal:
 | `npm run build`           | Build to `./dist/`                                  |
 | `npm run check`           | Check for TypeScript errors                         |
 | `npm run preview`         | Preview build locally at `localhost:4321`           |
+| `npm run publish-w3c`     | Like `build`, but with adjustments for WD and WAI   |
 | `npm run cspell`          | Check spelling (see words list in custom-words.txt) |
 
 ## Project Structure
@@ -52,6 +52,7 @@ Additional directories with special meaning:
       - `{guideline-name}/` - Subdirectory containing provisions (e.g. requirements/assertions) under each guideline
         - `{provision-name}.md` - Defines content of an individual provision
   - `terms/` - Contents of terms defined in the Glossary
+- `informative/` - contains content files for informative pages; see [Informative README](informative/README.md)
 
 ### Notable Subdirectories under `src`
 
@@ -152,7 +153,7 @@ Another shared term
 :   Another shared definition
 ```
 
-### Custom Directives for Guidelines Markdown
+### Custom Directives available to both Guidelines and Informative Docs
 
 For more concrete examples, search for these directives in the repository.
 
@@ -225,6 +226,17 @@ Your content here
 :::
 ```
 
+#### Glossary Term References
+
+The text inside `:term[...]` will be transformed into a link referencing a term in the glossary,
+and can be used inline within blocks of text:
+
+```
+... is :term[programmatically determinable].
+```
+
+### Custom Directives only available to Guidelines
+
 #### Applies when
 
 The following block will be preceded by "Applies when".
@@ -250,6 +262,7 @@ a condition is true.
 ```
 
 This follows the same behavior as `:::applies-when` regarding single paragraphs vs. other cases.
+If both `:::applies-when` and `:::except-when` exist for a requirement, they must appear in that order.
 
 #### Assertions replacements
 
@@ -268,15 +281,6 @@ The following leaf directives are to be used before required and recommended doc
 ```
 
 Note that these are leaf directives, not container directives, so there is no end marker.
-
-#### Glossary Term References
-
-The text inside `:term[...]` will be transformed into a link referencing a term in the glossary,
-and can be used inline within blocks of text:
-
-```
-... is :term[programmatically determinable].
-```
 
 ## Creating New Entries
 

--- a/README.md
+++ b/README.md
@@ -214,18 +214,6 @@ Your content here
 :::
 ```
 
-#### User Needs
-
-The following block will be transformed into a User Needs `details` element,
-with an indication that its content is non-normative.
-This is _only_ valid within guidelines.
-
-```
-:::user-needs
-Your content here
-:::
-```
-
 #### Glossary Term References
 
 The text inside `:term[...]` will be transformed into a link referencing a term in the glossary,

--- a/informative/README.md
+++ b/informative/README.md
@@ -1,0 +1,41 @@
+# WCAG 3 Informative Docs
+
+This folder contains the source content files used to assemble the informative documentation.
+
+## `informative` directory structure
+
+### `guidelines/` subdirectory
+
+This folder contains content files organized by guideline, then further by provision.
+Filenames are expected to match those found under the top-level `guidelines` folder.
+
+- `{group-name}/`
+  - `{guideline-name}.md` - Defines informative content for each guideline
+  - `{guideline-name}/` - Subdirectory containing provisions under each guideline
+    - `{provision-name}.md` - Defines informative content for each provision
+
+Note that information that is already defined in the `guidelines` folder,
+such as `children` and `title`, is inherited and therefore not re-specified
+inside the informative folder. (This is why there are no entries at the `{group-name}` level.)
+As such, these files should not need to include any frontmatter.
+
+Content files under this subdirectory can also make use of the [Custom Directives available to both Guidelines and Informative Docs](../README.md#custom-directives-available-to-both-guidelines-and-informative-docs).
+
+### `act-rules/`, `best-practices/`, and `methods/` subdirectories
+
+Each of these folders defines a specific type of supplementary content,
+and follows the following structure:
+
+- `{technology}/` - Where `{technology}` is one of `documents`, `mobile`, or `web`; in practice, only `web` has been used so far
+  - `{technology}/{filename}.md` - Contains a single ACT rule / best practice / method:
+    - `{filename}` should match what you would like the URL slug for this entry to look like
+    - The actual title and related provisions will be defined in frontmatter (see below)
+
+#### Supported Frontmatter Fields
+
+The following fields are required:
+
+- `title` - Title of the ACT rule, best practice, or method
+- `provisions` - List of slugs corresponding to applicable provisions for this entry;
+  this should _only_ specify the provision slug (not group or guideline),
+  e.g. `sections-labeled` rather than `layout/structure/sections-labeled`

--- a/src/lib/markdown/guidelines.ts
+++ b/src/lib/markdown/guidelines.ts
@@ -103,16 +103,6 @@ const customDirectives: RemarkPlugin = () => (tree, file) => {
           type: "html",
           value: "<summary>Which core requirements apply?</summary>",
         });
-      } else if (isGuideline && node.name === "user-needs") {
-        expectGuidelineFileType(file, "guideline", ":::user-needs");
-
-        const data = node.data || (node.data = {});
-        data.hName = "details";
-        data.hProperties = { class: "user-needs" };
-        node.children.unshift({
-          type: "html",
-          value: "<summary>User Needs</summary><p><em>This section is non-normative.</em></p>",
-        });
       } else if (isGuideline && node.name === "applies-when") {
         expectGuidelineFileType(file, "provision", ":::applies-when");
 


### PR DESCRIPTION
This adds a (long overdue) README under the informative folder to explain the expected file structure and (in the case of ACT Rules/etc.) frontmatter, cross-links the main and informative READMEs, and reorganizes the main README's documentation of directives to call out which ones apply both to `guidelines/` and `informative/`.

It also removes the `user-needs` directive, which is presently unused, and should no longer be necessary, as the User Needs section now lives in the informative files. (Note the diff might make this look like a change rather than a removal, due to relocating the `:term` docs to the appropriate section.)

The creation of `informative/README.md` is intended to support additional documentation for #774; I haven't included it here until we know for sure which of these PRs will land first.

I also confirmed that this doesn't affect the build, i.e. no content config wildcards are accidentally matching `informative/README.md`; they all look for files at deeper levels.