### PR TITLE
Informative docs: Move In brief section before normative content

### DIFF
--- a/src/lib/informative.ts
+++ b/src/lib/informative.ts
@@ -4,14 +4,18 @@ import {
   getEntry,
   type CollectionEntry,
   type CollectionKey,
-  type RenderedContent,
 } from "astro:content";
 import { load } from "cheerio";
 import noop from "lodash/noop";
 import sortBy from "lodash/sortBy";
 import pluralize from "pluralize";
 
-import { computeGuidelineTitle, computeTermTitle, provisionSlugMap } from "./guidelines";
+import {
+  computeGuidelineTitle,
+  computeProvisionTypeLabel,
+  computeTermTitle,
+  provisionSlugMap,
+} from "./guidelines";
 
 /**
  * Wraps a function call to silence its console.warn calls,
@@ -124,16 +128,31 @@ export async function resolveInformativeProvisions(guidelineId: string) {
   return provisions;
 }
 
-/** Formats normative content for inclusion within an informative page. */
-export function formatNormativeContent(rendered: RenderedContent) {
-  const $ = load(rendered.html, null, false);
-  $("summary").each((_, el) => {
-    const $el = $(el);
+/** Formats informative and normative content together for pages in informative docs. */
+export function incorporateNormativeContent(entry: InformativeGuideline | InformativeProvision) {
+  if (!entry.rendered || !entry.normativeEntry.rendered)
+    throw new Error(
+      `Rendered HTML missing for ${entry.id}; check for Markdown parse failures earlier in log`
+    );
+
+  const $normative = load(entry.normativeEntry.rendered.html, null, false);
+  $normative("summary").each((_, el) => {
+    const $el = $normative(el);
     // Add child element to summaries to work with WAI excol styles
     if ($el.text() === $el.html()) $el.html(`<strong>${$el.text()}</strong>`);
   });
+  if (entry.collection === "informativeGuidelines")
+    return `<h2>Guideline</h2><div class="normative">${$normative.html()}</div>${entry.rendered.html}`;
 
-  return `<div class="normative">${$.html()}</div>`;
+  const $ = load(
+    `<h2>${computeProvisionTypeLabel(entry.normativeEntry)}</h2>` +
+      `<div class="normative">${$normative.html()}</div>${entry.rendered.html}`,
+    null,
+    false
+  );
+  const $inBrief = $("h2#in-brief").first().nextUntil("h2").addBack();
+  if ($inBrief.length) $("h2").first().before($inBrief);
+  return $.html();
 }
 
 /** Inverted map from every possible permutation of each term to its content entry. */

--- a/src/pages/informative/[groupId]/[guidelineSlug]/[provisionSlug].astro
+++ b/src/pages/informative/[groupId]/[guidelineSlug]/[provisionSlug].astro
@@ -5,10 +5,9 @@ import capitalize from "lodash/capitalize";
 import KeyTerms from "@/components/informative/KeyTerms.astro";
 import InformativeLayout from "@/layouts/InformativeLayout.astro";
 import { informativeSlug } from "@/lib/constants";
-import { computeProvisionTypeLabel } from "@/lib/guidelines";
 import {
   detectTechnology,
-  formatNormativeContent,
+  incorporateNormativeContent,
   informativeProvisionSlugRelationMap,
   informativeRelatedTypes,
   processKeyTerms,
@@ -46,21 +45,15 @@ const guideline = await resolveInformativeGuideline(guidelineId);
 if (!guideline) throw new Error(`Unresolvable informative guideline ID: ${guidelineId}`);
 const provision = await resolveInformativeProvision(provisionId);
 if (!provision) throw new Error(`Unresolvable informative provision ID: ${provisionId}`);
-if (!provision.rendered || !provision.normativeEntry.rendered) {
-  throw new Error(
-    `how-to/[group]/[guideline]: Rendered HTML missing for ${provision.id}; check for Markdown parse failures earlier in log`
-  );
-}
 
 const { html, terms } = processKeyTerms(
-  formatNormativeContent(provision.normativeEntry.rendered) + provision.rendered.html
+  incorporateNormativeContent(provision)
 );
 
 const relatedEntries = informativeProvisionSlugRelationMap[provisionSlug!];
 ---
 
 <InformativeLayout title={provision.title} entry={provision} breadcrumbSegments={[guideline, provision]}>
-  <h2>{computeProvisionTypeLabel(provision.normativeEntry)}</h2>
   <Fragment set:html={html} />
   {
     relatedEntries && Object.entries(relatedEntries).map(([type, entries]) => (

--- a/src/pages/informative/[groupId]/[guidelineSlug]/index.astro
+++ b/src/pages/informative/[groupId]/[guidelineSlug]/index.astro
@@ -5,7 +5,7 @@ import KeyTerms from "@/components/informative/KeyTerms.astro";
 import ProvisionLink from "@/components/informative/ProvisionLink.astro";
 import InformativeLayout from "@/layouts/InformativeLayout.astro";
 import {
-  formatNormativeContent,
+  incorporateNormativeContent,
   processKeyTerms,
   resolveInformativeGroups,
   resolveInformativeGuideline,
@@ -33,21 +33,12 @@ const guidelineId = `${groupId}/${guidelineSlug}`;
 
 const guideline = await resolveInformativeGuideline(guidelineId);
 if (!guideline) throw new Error(`Unresolvable informative guideline ID: ${guidelineId}`);
-if (!guideline.rendered || !guideline.normativeEntry.rendered) {
-  throw new Error(
-    `informative/[group]/[guideline]: Rendered HTML missing for ${guideline.id}; check for Markdown parse failures earlier in log`
-  );
-}
 
 const provisions = await resolveInformativeProvisions(guidelineId);
-
-const { html, terms } = processKeyTerms(
-  formatNormativeContent(guideline.normativeEntry.rendered) + guideline.rendered.html
-);
+const { html, terms } = processKeyTerms(incorporateNormativeContent(guideline));
 ---
 
 <InformativeLayout title={guideline.title} entry={guideline} breadcrumbSegments={[guideline]}>
-  <h2>Guideline</h2>
   <Fragment set:html={html} />
   <h2>Provisions under this guideline</h2>
   {


### PR DESCRIPTION
This refactors how normative content is integrated into informative pages to allow for reorganizing the In brief section above the normative content.

I've reduced repetition across the two Astro templates that use this function, since the entire entry is passed to the function so it can do all of the work itself now.

**Note:** This will not have any visible effect in `main` without any In brief sections, e.g. those added in #753.

Here is a [preview](https://gist.githack.com/kfranqueiro/085248fd12cb821a81cf0de29c869d6b/raw/consistent-navigation-order.html) of what it does to one of the pages from #753 (compare to [#753 preview](https://deploy-preview-753--wcag3.netlify.app/informative/consistency-across-views/consistency/consistent-navigation-order/))