### PR TITLE
Migrate Methods to informative docs

### DIFF
--- a/guidelines/groups/animation-and-movement/avoid-physical-harm/audio-shifting-adjustable.md
+++ b/guidelines/groups/animation-and-movement/avoid-physical-harm/audio-shifting-adjustable.md
@@ -13,8 +13,3 @@ Audio shifting designed to create a perception of motion can be paused or turned
 :::except-when
 - operating system or user agent triggers audio shifting.
 :::
-
-:::ednote
-<b>Method(s)</b>
-* Add a setting to pause audio-shifting or turn it off.
-:::

--- a/guidelines/groups/animation-and-movement/avoid-physical-harm/haptic-stimulation-adjustable.md
+++ b/guidelines/groups/animation-and-movement/avoid-physical-harm/haptic-stimulation-adjustable.md
@@ -13,8 +13,3 @@ Haptic feedback can be reduced or turned off.
 :::except-when
 - the operating system or user agent converts non-haptic feedback to haptics at user request.
 :::
-
-:::ednote
-<b>Method(s)</b>
-* Add a setting to reduce haptic feedback or turn it off.
-:::

--- a/guidelines/groups/animation-and-movement/avoid-physical-harm/trigger-warning-available.md
+++ b/guidelines/groups/animation-and-movement/avoid-physical-harm/trigger-warning-available.md
@@ -12,8 +12,3 @@ A warning is provided before users encounter triggers and a mechanism is availab
 :::note
 Note: Triggers are flashing, motion lasting more than 5 seconds, and pseudo-motion.
 :::
-
-:::ednote
-<b>Method(s)</b>
-* Provide a warning for triggers and provide an option without the triggers.
-:::

--- a/guidelines/groups/error-handling/correct-errors/error-messages-persistent.md
+++ b/guidelines/groups/error-handling/correct-errors/error-messages-persistent.md
@@ -4,11 +4,3 @@ type: supplemental
 ---
 
 Error messages persist at least until the error is resolved or the user dismisses them.
-
-:::ednote
-Methods & best practices 
-* Method: Keep track of the state of the error and make visibility of the error message depending on this state.
-* Method: In a form, revalidate all fields when the form is submitted and remove all error messages that are no longer relevant.
-* Method: Add a "Dismiss" button to the error that makes the error message disappear.
-* Best Practice: [1-2 sentence description or a link to an example] 
-:::

--- a/guidelines/groups/input-operation/authentication/biometrics-not-relied-on.md
+++ b/guidelines/groups/input-operation/authentication/biometrics-not-relied-on.md
@@ -8,9 +8,3 @@ type: foundational
 :::note
 Biometrics includes facial recognition software, fingerprinting, vocal patterns and other voice characteristics.
 :::
-
-:::note
-Methods &amp; best practices
-
-- Method: When requiring biometric information for authentication, provide an additional way to authenticate that is not biometric. For example, if a finger print is required for authentication, then a password must also be supported.
-:::

--- a/guidelines/groups/input-operation/authentication/multiple-biometrics-available.md
+++ b/guidelines/groups/input-operation/authentication/multiple-biometrics-available.md
@@ -4,8 +4,3 @@ status: exploratory
 ---
 
 Authentication does not rely solely on a single type of :term[biometrics].
-
-:::ednote
-Methods & best practices
-* Method: When requiring biometric information for authentication, provide an additional way to authenticate (this may include using a different type of biometrics — for example, if a finger print is required for authentication, then voice authentication or a password must also be supported). 
-:::

--- a/guidelines/groups/input-operation/keyboard-interface-input/bidirectional-navigation.md
+++ b/guidelines/groups/input-operation/keyboard-interface-input/bidirectional-navigation.md
@@ -9,13 +9,6 @@ The keyboard interface can always move forward to the next interactive element a
 Although keyboard navigation is required to be bidirectional, it is not required that it be symmetrical, even though this is usually best practice.
 :::
 
-:::note
-Methods &amp; best practices:
-
-- Method: Use standard HTML to create interactive elements.
-- Avoid modifying the tab order to be in only one direction.
-:::
-
 :::example
 Tabbing through menus, hitting <kbd>space</kbd> to open a menu, tabbing off the end of the menu lands you on the next menu. A <kbd><kbd>shift</kbd>+<kbd>tab</kbd></kbd> may go back to the last item in the previous menu (symmetrical) or to the last menu (not symmetrical but also does not fail this requirement).
 :::

--- a/guidelines/groups/input-operation/keyboard-interface-input/focus-placed.md
+++ b/guidelines/groups/input-operation/keyboard-interface-input/focus-placed.md
@@ -12,9 +12,3 @@ When a user closes a modal dialog or other popup, keyboard focus is returned to 
 :::example
 When there are tags, with a delete button on each tag, the keyboard focus needs to be moved to a meaningful location after a tag is deleted.
 :::
-
-:::ednote
-Method: When removing interactive elements such as filters, dialogs, or popups that currently contain focus, actively place the focus back on the element that led to that element, the previous element within the focus order, or another meaningful location.
-
-Best Practice: Conduct usability testing with screen reader users to evaluate the focus movement. 
-:::

--- a/guidelines/groups/input-operation/physical-or-cognitive-effort-when-using-keyboard/no-repetitive-links.md
+++ b/guidelines/groups/input-operation/physical-or-cognitive-effort-when-using-keyboard/no-repetitive-links.md
@@ -12,11 +12,3 @@ Supplemental if applicable to all :term[content], else best practice.
 :::note
 A common pattern is having a :term[component] that includes a linked image and some linked :term[text], where both links go to the same content. Someone using screen reading software can be disoriented from the unnecessary chatter, and a keyboard user has to navigate through more tab stops than should be necessary. Combining adjacent links that go to the same content improves the user experience.
 :::
-
-:::note
-Methods &amp; best practices
-
-- Method: When repetitive links are used, remove them from the focus and reading order.
-- Method: Use a single link instead of multiple links to the same destination.
-- Best practice: Combine repetitive links into a single interactive element.
-:::

--- a/guidelines/groups/input-operation/pointer-input/pointer-pressure-not-relied-on.md
+++ b/guidelines/groups/input-operation/pointer-input/pointer-pressure-not-relied-on.md
@@ -12,9 +12,3 @@ Specific :term[pointer] pressure is not the only way of achieving any functional
 :::example
 Specific pressure would be essential to a paintbrush feature or advanced signature verification.
 :::
-
-:::note
-Methods &amp; best practices:
-
-Method: When building in functionality that relies on pointer pressure, add a slider or other control that can complete the same functionality.
-:::

--- a/guidelines/groups/input-operation/speech-and-voice-input/real-time-text-available.md
+++ b/guidelines/groups/input-operation/speech-and-voice-input/real-time-text-available.md
@@ -5,9 +5,3 @@ title: Real-time text available
 ---
 
 A real-time text option is available for real-time bidirectional voice communication.
-
-:::ednote
-Methods &amp; best practices
-
-Method: Provide a chat option for any voice communication
-:::

--- a/guidelines/groups/input-operation/speech-and-voice-input/speech-not-relied-on.md
+++ b/guidelines/groups/input-operation/speech-and-voice-input/speech-not-relied-on.md
@@ -8,9 +8,3 @@ Content or functionality does not rely on speech alone.
 :::except-when
 - Speech input is :term[essential] to the functionality.
 :::
-
-:::ednote
-Methods &amp; best practices 
-
-Method: When speech input is supported, an additional way of providing input is also supported.
-:::

--- a/guidelines/groups/interactive-components/control-information/changes-to-elements-notified.md
+++ b/guidelines/groups/interactive-components/control-information/changes-to-elements-notified.md
@@ -4,11 +4,3 @@ type: foundational
 ---
 
 Changes to :term[interactive elements]' names, roles, values or states are visually and :term[programmatically indicated].
-
-:::ednote
-Methods &amp; best practices:
-
-- Method: Add code that clearly defines the name, role, value and state.
-- Method: visually indicate the names, roles and values of the interactive element.
-- Method: HTML - html tags or aria
-:::

--- a/guidelines/groups/interactive-components/control-information/input-constraints-used.md
+++ b/guidelines/groups/interactive-components/control-information/input-constraints-used.md
@@ -4,11 +4,3 @@ type: foundational
 ---
 
 Field constraints and conditions (required line length, date format, password format, etc.) are available.
-
-:::ednote
-Methods &amp; best practices
-
-- Method (HTML): to programmatically indicate, use the pattern attribute or write the information in a label; to visually indicate, add the requirements to the page near the input.
-
-Best practice: the constraints remain persistent
-:::

--- a/guidelines/groups/interactive-components/control-information/interactive-element-names-available.md
+++ b/guidelines/groups/interactive-components/control-information/interactive-element-names-available.md
@@ -8,11 +8,3 @@ Persistent names (including labels) that identify the purpose of the interactive
 :::note
 Visible labels can be text or non-text, for instance icons.
 :::
-
-:::ednote
-Methods &amp; best practices
-
-- Method: Provide unique, descriptive text or image (icon) for each interactive element. 
-- Best Practice: Ensure clarity by pairing an icon with a persistent visible text label or only use a persistent visible text label. 
-- Best Practice: When an icon is the only visual label, provide a tooltip (hover label) with the text description.
-:::

--- a/guidelines/groups/interactive-components/control-information/interactive-elements-distinguishable.md
+++ b/guidelines/groups/interactive-components/control-information/interactive-elements-distinguishable.md
@@ -4,11 +4,3 @@ type: supplemental
 ---
 
 :term[Interactive elements] are visually distinguishable without interaction from static :term[content] and include visual cues on how to use them.
-
-:::note
-Methods &amp; best practices
-
-- Method: Add visual indicators such as shading, border, drop down arrow, placement, etc. to interactive elements.
-- Best Practice: Document interactive indicators and designs in style guide
-:::
-

--- a/guidelines/groups/interactive-components/control-information/label-included-in-programmatic-name.md
+++ b/guidelines/groups/interactive-components/control-information/label-included-in-programmatic-name.md
@@ -4,10 +4,3 @@ type: foundational
 ---
 
 The programmatic name includes the visual label.
-
-:::ednote
-Methods &amp; best practices
-
-- Method: Code the same name as you display.
-- Best Practice: Use unique names and keep the programmatic and visual names the same.
-:::

--- a/guidelines/groups/interactive-components/control-information/roles-values-states-properties-available.md
+++ b/guidelines/groups/interactive-components/control-information/roles-values-states-properties-available.md
@@ -5,10 +5,3 @@ type: foundational
 ---
 
 Accurate names, roles, values, and :term[states] are available for :term[interactive elements].
-
-:::ednote
-Methods &amp; best practices
-
-- Method (HTML): use HTML elements according to specification.
-- Method (ARIA): add roles, values, states, and properties according to specification.
-:::

--- a/guidelines/groups/interactive-components/expected-behavior/consistent-control-location.md
+++ b/guidelines/groups/interactive-components/expected-behavior/consistent-control-location.md
@@ -8,11 +8,3 @@ Where an :term[interactive element] with the same purpose is used across :term[p
 - The location changes due to a page variation or viewport change, or
 - The layout changes due to being part of a process (such as e-commerce checkout).
 :::
-
-:::ednote
-Methods &amp; best practices
-
-- Method: Establish a design system with documented rules for consistent placement of common interactive components (for example, navigation menus, search bars, and action buttons).
-- Method: Reuse the same components across pages/views instead of recreating them.
-- Best practice: If a visual position must change, document why and consider providing cues (for example, animations and labels) to reduce confusion.
-:::

--- a/guidelines/groups/interactive-components/pointer-focus-appearance/default-pointer-used.md
+++ b/guidelines/groups/interactive-components/pointer-focus-appearance/default-pointer-used.md
@@ -8,10 +8,3 @@ The user can ensure that the appearance of the :term[pointer] is not overridden 
 :::except-when
 - Changing the pointer appearance is essential.
 :::
-
-:::ednote
-Methods &amp; best practices:
-
-- No scripting or styling overrides the pointer indicator appearance.
-- A setting is provided so that the pointer indicator appearance is not overridden.
-:::

--- a/guidelines/groups/interactive-components/pointer-focus-appearance/enhanced-pointer-available.md
+++ b/guidelines/groups/interactive-components/pointer-focus-appearance/enhanced-pointer-available.md
@@ -4,9 +4,3 @@ type: supplemental
 ---
 
 Provide a more visible :term[pointer] indicator than the platform default. The enhanced pointer indicator can be enabled in a setting, and be visible temporarily (for a few seconds) or permanently.
-
-:::note
-Methods &amp; best practices:
-
-- Provide a setting to adjust the pointer indicator.
-:::

--- a/guidelines/groups/interactive-components/pointer-focus-appearance/pointer-focus-indicated.md
+++ b/guidelines/groups/interactive-components/pointer-focus-appearance/pointer-focus-indicated.md
@@ -17,10 +17,3 @@ Examples of pointers which do not always show the pointer indicator:
 - An eye-tracking interface highlights the element under the gaze of the user, but otherwise does not have a pointer indicator. 
 - A game where you use the pointer to move the entire view around a virtual environment.
 :::
-
-:::note
-Methods &amp; best practices:
-
-- Method: Interactive elements are highlighted when the pointer is on the element. 
-For example, a set of image-links are shown, and the one under the pointer is highlighted with an outline or size-change.
-:::

--- a/guidelines/groups/interactive-components/pointer-focus-appearance/pointer-visible.md
+++ b/guidelines/groups/interactive-components/pointer-focus-appearance/pointer-visible.md
@@ -9,9 +9,3 @@ The :term[pointer] indicator is always visible.
 - The pointer is on a video and is not moving.
 - The pointer controls the direction of view in a virtual or real world environment.
 :::
-
-:::note
-Methods &amp; best practices
-
-- Method: No styling or scripting hides the pointer indicator.
-:::

--- a/guidelines/groups/layout/no-obstruction/overlay-content-dismissible.md
+++ b/guidelines/groups/layout/no-obstruction/overlay-content-dismissible.md
@@ -4,9 +4,3 @@ status: developing
 ---
 
 When new content becomes visible and covers the main content, a mechanism is available to dismiss the new content.
-
-:::ednote
-Methods
-* The 'Escape' (<kbd>Esc</kbd>) key closes new content.
-* An accessible 'close' button is provided to close the new content. 
-:::

--- a/informative/guidelines/animation-and-movement/avoid-physical-harm/audio-shifting-adjustable.md
+++ b/informative/guidelines/animation-and-movement/avoid-physical-harm/audio-shifting-adjustable.md
@@ -1,3 +1,7 @@
+## Methods
+
+* Add a setting to pause audio shifting or turn it off.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/animation-and-movement/avoid-physical-harm/haptic-stimulation-adjustable.md
+++ b/informative/guidelines/animation-and-movement/avoid-physical-harm/haptic-stimulation-adjustable.md
@@ -1,3 +1,7 @@
+## Methods
+
+* Add a setting to reduce haptic feedback or turn it off.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/animation-and-movement/avoid-physical-harm/trigger-warning-available.md
+++ b/informative/guidelines/animation-and-movement/avoid-physical-harm/trigger-warning-available.md
@@ -1,3 +1,7 @@
+## Methods
+
+* Provide a warning for triggers and provide an option without the triggers.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/error-handling/correct-errors/error-messages-persistent.md
+++ b/informative/guidelines/error-handling/correct-errors/error-messages-persistent.md
@@ -1,3 +1,9 @@
+## Methods
+
+* Keep track of the state of the error and make visibility of the error message depending on this state.
+* In a form, revalidate all fields when the form is submitted and remove all error messages that are no longer relevant.
+* Add a "Dismiss" button to the error that makes the error message disappear.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/input-operation/authentication/biometrics-not-relied-on.md
+++ b/informative/guidelines/input-operation/authentication/biometrics-not-relied-on.md
@@ -1,3 +1,7 @@
+## Methods
+
+- When requiring biometric information for authentication, provide an additional way to authenticate that is not biometric. For example, if a fingerprint is required for authentication, then a password must also be supported.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/input-operation/authentication/multiple-biometrics-available.md
+++ b/informative/guidelines/input-operation/authentication/multiple-biometrics-available.md
@@ -1,3 +1,7 @@
+## Methods
+
+* When requiring biometric information for authentication, provide an additional way to authenticate (this may include using a different type of biometrics — for example, if a fingerprint is required for authentication, then voice authentication or a password must also be supported). 
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/input-operation/keyboard-interface-input/bidirectional-navigation.md
+++ b/informative/guidelines/input-operation/keyboard-interface-input/bidirectional-navigation.md
@@ -1,3 +1,11 @@
+## Methods
+
+- Use standard HTML to create interactive elements.
+
+## Best Practices
+
+- Avoid modifying the tab order to be in only one direction.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/input-operation/keyboard-interface-input/focus-placed.md
+++ b/informative/guidelines/input-operation/keyboard-interface-input/focus-placed.md
@@ -1,3 +1,11 @@
+## Methods
+
+- When removing interactive elements such as filters, dialogs, or popups that currently contain focus, actively place the focus back on the element that led to that element, the previous element within the focus order, or another meaningful location.
+
+## Best Practices
+
+- Conduct usability testing with screen reader users to evaluate the focus movement.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/input-operation/physical-or-cognitive-effort-when-using-keyboard/no-repetitive-links.md
+++ b/informative/guidelines/input-operation/physical-or-cognitive-effort-when-using-keyboard/no-repetitive-links.md
@@ -1,3 +1,12 @@
+## Methods
+
+- When repetitive links are used, remove them from the focus and reading order.
+- Use a single link instead of multiple links to the same destination.
+
+## Best Practices
+
+- Combine repetitive links into a single interactive element.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/input-operation/pointer-input/pointer-pressure-not-relied-on.md
+++ b/informative/guidelines/input-operation/pointer-input/pointer-pressure-not-relied-on.md
@@ -1,3 +1,7 @@
+## Methods
+
+- When building in functionality that relies on pointer pressure, add a slider or other control that can complete the same functionality.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/input-operation/speech-and-voice-input/real-time-text-available.md
+++ b/informative/guidelines/input-operation/speech-and-voice-input/real-time-text-available.md
@@ -1,3 +1,7 @@
+## Methods
+
+- Provide a chat option for any voice communication.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/input-operation/speech-and-voice-input/speech-not-relied-on.md
+++ b/informative/guidelines/input-operation/speech-and-voice-input/speech-not-relied-on.md
@@ -1,3 +1,7 @@
+## Methods
+
+- When speech input is supported, an additional way of providing input is also supported.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/interactive-components/control-information/changes-to-elements-notified.md
+++ b/informative/guidelines/interactive-components/control-information/changes-to-elements-notified.md
@@ -1,3 +1,9 @@
+## Methods
+
+- Add code that clearly defines the name, role, value and state.
+- Visually indicate the names, roles, and values of the interactive element.
+- HTML: HTML tags or ARIA
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/interactive-components/control-information/input-constraints-used.md
+++ b/informative/guidelines/interactive-components/control-information/input-constraints-used.md
@@ -1,3 +1,11 @@
+## Methods
+
+- HTML: To programmatically indicate, use the `pattern` attribute or write the information in a label; to visually indicate, add the requirements to the page near the input.
+
+## Best Practices
+
+- The constraints remain persistent.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/interactive-components/control-information/interactive-element-names-available.md
+++ b/informative/guidelines/interactive-components/control-information/interactive-element-names-available.md
@@ -1,3 +1,12 @@
+## Methods
+
+- Provide unique, descriptive text or image (icon) for each interactive element.
+
+## Best Practices
+
+- To ensure clarity, pair an icon with a persistent visible text label, or only use a persistent visible text label.
+- When an icon is the only visual label, provide a tooltip (hover label) with the text description.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/interactive-components/control-information/interactive-elements-distinguishable.md
+++ b/informative/guidelines/interactive-components/control-information/interactive-elements-distinguishable.md
@@ -1,1 +1,9 @@
+## Methods
+
+- Add visual indicators, such as shading, border, drop-down arrow, or placement, to interactive elements.
+
+## Best Practices
+
+- Document interactive indicators and designs in a style guide.
+
 ## Tests

--- a/informative/guidelines/interactive-components/control-information/label-included-in-programmatic-name.md
+++ b/informative/guidelines/interactive-components/control-information/label-included-in-programmatic-name.md
@@ -1,3 +1,11 @@
+## Methods
+
+- Code the same name as you display.
+
+## Best Practices
+
+- Use unique names and keep the programmatic and visual names the same.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/interactive-components/control-information/roles-values-states-properties-available.md
+++ b/informative/guidelines/interactive-components/control-information/roles-values-states-properties-available.md
@@ -1,3 +1,8 @@
+## Methods
+
+- HTML: Use HTML elements according to specification.
+- ARIA: Add roles, values, states, and properties according to specification.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/interactive-components/expected-behavior/consistent-control-location.md
+++ b/informative/guidelines/interactive-components/expected-behavior/consistent-control-location.md
@@ -1,3 +1,12 @@
+## Methods
+
+- Establish a design system with documented rules for consistent placement of common interactive components (for example, navigation menus, search bars, and action buttons).
+- Reuse the same components across pages/views instead of recreating them.
+
+## Best Practices
+
+- If a visual position must change, document why and consider providing cues (for example, animations and labels) to reduce confusion.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/interactive-components/pointer-focus-appearance/default-pointer-used.md
+++ b/informative/guidelines/interactive-components/pointer-focus-appearance/default-pointer-used.md
@@ -1,3 +1,8 @@
+## Methods
+
+- No scripting or styling overrides the pointer indicator appearance.
+- Provide a setting that removes any overrides to the pointer indicator appearance.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/interactive-components/pointer-focus-appearance/enhanced-pointer-available.md
+++ b/informative/guidelines/interactive-components/pointer-focus-appearance/enhanced-pointer-available.md
@@ -1,3 +1,7 @@
+## Methods
+
+- Provide a setting to adjust the pointer indicator.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/interactive-components/pointer-focus-appearance/pointer-focus-indicated.md
+++ b/informative/guidelines/interactive-components/pointer-focus-appearance/pointer-focus-indicated.md
@@ -1,3 +1,8 @@
+## Methods
+
+- Interactive elements are highlighted when the pointer is on the element. 
+  For example, a set of image links are shown, and the one under the pointer is highlighted with an outline or change in size.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/interactive-components/pointer-focus-appearance/pointer-visible.md
+++ b/informative/guidelines/interactive-components/pointer-focus-appearance/pointer-visible.md
@@ -1,3 +1,7 @@
+## Methods
+
+- No styling or scripting hides the pointer indicator.
+
 ## Tests
 
 <b>Procedure</b>

--- a/informative/guidelines/layout/no-obstruction/overlay-content-dismissible.md
+++ b/informative/guidelines/layout/no-obstruction/overlay-content-dismissible.md
@@ -1,3 +1,8 @@
+## Methods
+
+- The 'Escape' (<kbd>Esc</kbd>) key closes new content.
+- An accessible 'close' button is provided to close the new content. 
+
 ## Tests
 
 ### Modal dialogs on interaction


### PR DESCRIPTION
This migrates any instances of "Method(s)" found in TR-space ednotes to the respective informative files, and intentionally drops the parentheses around "s".

Note this intentionally skips instances that are already covered in #628 and #773.