### PR TITLE
Grammar pass on applies/except when

### DIFF
--- a/guidelines/groups/animation-and-movement/avoid-physical-harm/trigger-warning-available.md
+++ b/guidelines/groups/animation-and-movement/avoid-physical-harm/trigger-warning-available.md
@@ -6,9 +6,9 @@ type: foundational
 A warning is provided before users encounter triggers and a mechanism is available to access the same information without the triggering :term[content].
 
 :::applies-when
-- triggers are present
+- triggers are present.
 :::
 
 :::note
-Note: Triggers are flashing, motion lasting more than 5 seconds, and pseudo-motion.
+Triggers are flashing, motion lasting more than 5 seconds, and pseudo-motion.
 :::

--- a/guidelines/groups/consistency-across-views/consistency/consistent-navigation-order.md
+++ b/guidelines/groups/consistency-across-views/consistency/consistent-navigation-order.md
@@ -6,7 +6,7 @@ status: developing
 The relative order of navigation items is consistent within blocks of navigation that are repeated on multiple pages/views of the :term[conformance scope] or process.
 
 :::applies-when
-- In a set of :term[pages]/:term[views]
+- In a set of :term[pages]/:term[views].
 :::
 
 :::ednote

--- a/guidelines/groups/consistency-across-views/consistency/consistent-structural-order.md
+++ b/guidelines/groups/consistency-across-views/consistency/consistent-structural-order.md
@@ -6,7 +6,7 @@ status: developing
 The relative order of :term[structural components] remains consistent throughout each variation of :term[pages]/:term[views] in the :term[conformance scope].
 
 :::applies-when
-- In a set of :term[pages]/:term[views]
+- In a set of :term[pages]/:term[views].
 :::
 
 :::note

--- a/guidelines/groups/images-and-media/captions/captions-controllable.md
+++ b/guidelines/groups/images-and-media/captions/captions-controllable.md
@@ -6,5 +6,5 @@ status: developing
 A :term[mechanism] is available to turn :term[captions] on and off.
 
 :::except-when
-- Captions are hard coded into the video content.
+- Captions are hard-coded into the video content.
 :::

--- a/guidelines/groups/images-and-media/image-alternatives/image-types-identified.md
+++ b/guidelines/groups/images-and-media/image-alternatives/image-types-identified.md
@@ -6,9 +6,9 @@ type: supplemental
 The :term[image types] (photo, illustration, chart, etc.) are indicated.
 
 :::except-when
-* An image is a link or a part of a link
-* An image is a button or a part of a button
-* An image is "purely" decorative (e.g. icon used alongside text, thumbnail image within a link)
+* An image is a link or a part of a link.
+* An image is a button or a part of a button.
+* An image is "purely" :term[decorative] (e.g. icon used alongside text, thumbnail image within a link).
 :::
 
 :::example

--- a/guidelines/groups/images-and-media/media-alternatives/media-alternatives-equivalent.md
+++ b/guidelines/groups/images-and-media/media-alternatives/media-alternatives-equivalent.md
@@ -6,5 +6,5 @@ status: developing
 :term[Equivalent] :term[media alternatives] are :term[available] for :term[audio] and :term[video] content.
 
 :::except-when
-- It is a background video with no spoken content.
+- The video has no spoken content and serves only as background.
 :::

--- a/guidelines/groups/images-and-media/media-alternatives/media-alternatives-findable.md
+++ b/guidelines/groups/images-and-media/media-alternatives/media-alternatives-findable.md
@@ -6,5 +6,5 @@ status: developing
 A :term[mechanism] is :term[available] within the page/view to access the :term[media alternatives] for audio and video.
 
 :::except-when
-- It is a decorative audio or video.
+- The audio or video is :term[decorative].
 :::

--- a/guidelines/groups/images-and-media/media-alternatives/sounds-identified.md
+++ b/guidelines/groups/images-and-media/media-alternatives/sounds-identified.md
@@ -14,5 +14,5 @@ This includes sound effects and other non-spoken :term[audio] :term[content].
 :::
 
 :::except-when
-- it is a decorative video.
+- the video is :term[decorative].
 :::

--- a/guidelines/groups/images-and-media/media-alternatives/transcripts-available.md
+++ b/guidelines/groups/images-and-media/media-alternatives/transcripts-available.md
@@ -7,5 +7,5 @@ status: developing
 
 :::except-when
 * The audio or video content is an alternative for text and clearly labelled as such.
-* It is a background video with no spoken content.
+* The video has no spoken content and serves only as background.
 :::

--- a/guidelines/groups/images-and-media/sign-language/sign-language-available-prerecorded.md
+++ b/guidelines/groups/images-and-media/sign-language/sign-language-available-prerecorded.md
@@ -8,7 +8,7 @@ title: Sign language available (prerecorded)
 
 :::except-when
 - The audio content is an alternative for visual content and clearly labelled as such.
-- The audio content is decorative background sound.
+- The audio content is :term[decorative] background sound.
 - The audio is an :term[interface sound effect].
 :::
 

--- a/guidelines/groups/input-operation/keyboard-interface-input/no-keyboard-traps.md
+++ b/guidelines/groups/input-operation/keyboard-interface-input/no-keyboard-traps.md
@@ -6,7 +6,7 @@ type: foundational
 Components that can be activated or entered using the keyboard interface, can be deactivated or exited using a standard keyboard navigation-operation technique, standard platform keyboard commands.
 
 :::except-when
-- The non-standard keyboard navigation technique is described on the :term[page]/:term[view] or earlier in the :term[process].
+- The non-standard keyboard navigation technique is described in the :term[page]/:term[view] or earlier in the :term[process].
 ::: 
 
 :::example

--- a/guidelines/groups/interactive-components/control-information/interactive-element-contrast-sufficient.md
+++ b/guidelines/groups/interactive-components/control-information/interactive-element-contrast-sufficient.md
@@ -7,5 +7,5 @@ Visual information required to identify :term[interactive elements] and states m
 
 :::except-when
 * the interactive element is inactive, or 
-* when the appearance of the component is determined by the :term[user agent] and not modified by the content author.
+* the appearance of the component is determined by the :term[user agent] and not modified by the content author.
 :::

--- a/guidelines/groups/process-and-task-completion/adequate-time/time-limits-conveyed.md
+++ b/guidelines/groups/process-and-task-completion/adequate-time/time-limits-conveyed.md
@@ -6,9 +6,9 @@ type: supplemental
 Users are informed at the start of the process or session that a time limit exists, its length, and that it can be adjusted.
 
 :::applies-when 
-- :term[pages]/:term[views] within the :term[conformance scope] have a time limit 
+- :term[pages]/:term[views] within the :term[conformance scope] have a time limit.
 :::
 
 :::except-when 
-- hiding the existence of the time limit is essential
+- hiding the existence of the time limit is essential.
 :::

--- a/guidelines/groups/process-and-task-completion/avoid-deception/no-artificial-time-limits.md
+++ b/guidelines/groups/process-and-task-completion/avoid-deception/no-artificial-time-limits.md
@@ -6,5 +6,5 @@ type: supplemental
 The completion of a process does not include artificial time limits. 
 
 :::except-when
-* Time limit is :term[essential] such as in an auction, ticket sales, or a timed exam. 
+* The time limit is :term[essential] such as in an auction, ticket sales, or a timed exam. 
 :::

--- a/guidelines/groups/text-and-wording/clear-language/abbreviations-explained.md
+++ b/guidelines/groups/text-and-wording/clear-language/abbreviations-explained.md
@@ -9,7 +9,7 @@ Explanations of :term[abbreviations] are available when first used.
 - the abbreviation is:
     * used so often it has become a word with its own dictionary entry, such as "scuba," "info," and "HTML"
     * used in a logo
-    * included in a longer phrase, such as "brand DNA," whose meaning needs to be defined to meet the [non-literal language requirement](#non-literal-language-explained). 
+    * included in a longer phrase, such as "brand DNA," whose meaning needs to be defined to meet the [non-literal language requirement](#non-literal-language-explained)
 :::
 
 :::example

--- a/guidelines/groups/text-and-wording/clear-language/common-words-used.md
+++ b/guidelines/groups/text-and-wording/clear-language/common-words-used.md
@@ -6,7 +6,7 @@ type: supplemental
 Common words are used, and definitions are available for uncommon words. 
 
 :::applies-when
-* :term[human languages] have more than 1,500 words
+* :term[human languages] have more than 1,500 words.
 :::
 
 :::except-when

--- a/guidelines/groups/text-and-wording/text-appearance/text-color-adjustable.md
+++ b/guidelines/groups/text-and-wording/text-appearance/text-color-adjustable.md
@@ -15,10 +15,10 @@ The requirement is that the text is manipulable and the colors can be overridden
 
 :::except-when
 - the text is:
-    * also present elsewhere in the :term[page]/:term[view] which meets the requirement,
-    * part of an inactive Interactive element, 
-    * pure decoration, 
-    * not visible to anyone,
-    * part of a picture that includes significant other visual content,
-    * part of a logo.
+    * also present elsewhere in the :term[page]/:term[view] which meets the requirement
+    * part of an inactive Interactive element
+    * pure decoration
+    * not visible to anyone
+    * part of a picture that includes significant other visual content
+    * part of a logo
 :::

--- a/guidelines/groups/text-and-wording/text-appearance/text-color-adjustable.md
+++ b/guidelines/groups/text-and-wording/text-appearance/text-color-adjustable.md
@@ -16,7 +16,7 @@ The requirement is that the text is manipulable and the colors can be overridden
 :::except-when
 - the text is:
     * also present elsewhere in the :term[page]/:term[view] which meets the requirement
-    * part of an inactive Interactive element
+    * part of an inactive :term[interactive element]
     * pure decoration
     * not visible to anyone
     * part of a picture that includes significant other visual content

--- a/guidelines/groups/text-and-wording/text-appearance/text-contrast-sufficient-enhanced.md
+++ b/guidelines/groups/text-and-wording/text-appearance/text-contrast-sufficient-enhanced.md
@@ -17,7 +17,7 @@ The contrast algorithm used in WCAG 3 is yet to be determined. For this draft, t
 :::except-when
 - the text is:
     * also present elsewhere in the :term[page]/:term[view] which meets the requirement
-    * part of an inactive Interactive element
+    * part of an inactive :term[interactive element]
     * pure decoration
     * not visible to anyone
     * part of a picture that includes significant other visual content

--- a/guidelines/groups/text-and-wording/text-appearance/text-contrast-sufficient-enhanced.md
+++ b/guidelines/groups/text-and-wording/text-appearance/text-contrast-sufficient-enhanced.md
@@ -16,10 +16,10 @@ The contrast algorithm used in WCAG 3 is yet to be determined. For this draft, t
 
 :::except-when
 - the text is:
-    * also present elsewhere in the :term[page]/:term[view] which meets the requirement,
-    * part of an inactive Interactive element, 
-    * pure decoration, 
-    * not visible to anyone,
-    * part of a picture that includes significant other visual content,
-    * part of a logo.
+    * also present elsewhere in the :term[page]/:term[view] which meets the requirement
+    * part of an inactive Interactive element
+    * pure decoration
+    * not visible to anyone
+    * part of a picture that includes significant other visual content
+    * part of a logo
 :::

--- a/guidelines/groups/text-and-wording/text-appearance/text-contrast-sufficient-minimum.md
+++ b/guidelines/groups/text-and-wording/text-appearance/text-contrast-sufficient-minimum.md
@@ -13,7 +13,7 @@ The :term[default visual presentation] of text meets @@[contrast measure to be d
 :::except-when
 - the text is:
     * also present elsewhere in the :term[page]/:term[view] which meets the requirement
-    * part of an inactive Interactive element
+    * part of an inactive :term[interactive element]
     * pure decoration
     * not visible to anyone
     * part of a picture that includes significant other visual content

--- a/guidelines/groups/text-and-wording/text-appearance/text-contrast-sufficient-minimum.md
+++ b/guidelines/groups/text-and-wording/text-appearance/text-contrast-sufficient-minimum.md
@@ -12,12 +12,12 @@ The :term[default visual presentation] of text meets @@[contrast measure to be d
 
 :::except-when
 - the text is:
-    * also present elsewhere in the :term[page]/:term[view] which meets the requirement,
-    * part of an inactive Interactive element, 
-    * pure decoration, 
-    * not visible to anyone,
-    * part of a picture that includes significant other visual content,
-    * part of a logo or brand name.
+    * also present elsewhere in the :term[page]/:term[view] which meets the requirement
+    * part of an inactive Interactive element
+    * pure decoration
+    * not visible to anyone
+    * part of a picture that includes significant other visual content
+    * part of a logo or brand name
 :::
 
 :::note


### PR DESCRIPTION
This performs a light grammar pass on the applies/except-when directives.

"Light" as in, e.g.:

- I didn't bother making changes that might make the input files more consistent between each other but wouldn't affect output due to existing build system normalization.
- I also see, but did not pursue in this PR, some potential opportunity for further clarification of lists with multiple items, e.g. starting each with "{all,any} of the following are true" in place of "and" or "or" at the end of the list's penultimate item, which a couple of lists do right now.