### PR TITLE
Incorporate pre/code styles from w3c/wcag#4683

### DIFF
--- a/src/layouts/InformativeLayout.astro
+++ b/src/layouts/InformativeLayout.astro
@@ -89,6 +89,20 @@ const { breadcrumbSegments, entry, title, withNav = true } = Astro.props;
     margin: 0;
   }
 
+  pre {
+    padding: 1em;
+    border: 1px solid var(--line-grey);
+    background-color: var(--pure-white);
+  }
+
+  /* inline code not in a preformatted block or link */
+  :not(:is(pre, a)) > code {
+    font-size: 0.85em;
+    background: #ebebeb;
+    padding: 0 0.25em;
+    display: inline-block;
+  }
+
   .button--skip-link {
     background-color: var(--gold) !important;
     border-color: var(--gold) !important;


### PR DESCRIPTION
This borrows styles originally introduced by Patrick in w3c/wcag#4683 to make code blocks and inline code in informative docs stand out more.

- [Page with code blocks](https://deploy-preview-797--wcag3.netlify.app/informative/act-rules/web/html-page-non-empty-title/)
- [Page with inline attribute names](https://deploy-preview-797--wcag3.netlify.app/informative/images-and-media/image-alternatives/decorative-images-hidden/)

@netlify /informative/