### PR TITLE
Consistently sort ACT Rules / Best Practices / Methods lists

### DIFF
--- a/src/layouts/InformativeRelatedIndexLayout.astro
+++ b/src/layouts/InformativeRelatedIndexLayout.astro
@@ -22,7 +22,11 @@ interface Props {
 
 const { collectionName } = Astro.props;
 
-const collection = await getCollection(collectionName);
+const collection = (await getCollection(collectionName)).sort((a, b) => {
+  if (a.data.title < b.data.title) return -1;
+  if (a.data.title > b.data.title) return 1;
+  return 0;
+});
 const relatedInformativeType = informativeRelatedTypes[collectionName];
 ---
 


### PR DESCRIPTION
This fixes inconsistent sorting in the index pages for ACT Rules, Best Practices, and Methods, which I'd noticed when performing some build diffs locally.

(Astro docs specifically say you need to sort collections yourself and that the default is non-deterministic and system-dependent)

@netlify /informative/act-rules/