### PR TITLE
chore: use built-in cSpell HTML regex

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -34,14 +34,13 @@ patterns:
     pattern: /\[\[[^\]]+\]\]/g
   - name: foreign-language
     pattern: /<(\w+)[^>]+lang="(?!en)\w+"[^>]*>.*?<\/\1>/gi
-  - name: html-tags
-    pattern: /<[^>]*>/g
 languageSettings:
   - languageId: astro
     ignoreRegExpList:
       - encoded-citations
       - foreign-language
-      - html-tags
+      - HTML-id
+      - HTML-class
       # pre/code tags
       - /<(pre|code)\b[^>]*>[\s\S]*?<\/\1>/g
       # style tags
@@ -54,7 +53,8 @@ languageSettings:
     ignoreRegExpList:
       - encoded-citations
       - foreign-language
-      - html-tags
+      - HTML-id
+      - HTML-class
       # Block directive
       - /^\s*:::.*/gm
       # Fenced code block

--- a/cspell.yml
+++ b/cspell.yml
@@ -1,7 +1,6 @@
 version: "0.2"
 minWordLength: 3
-language:
-  - en-us
+language: "en-US"
 dictionaries:
   - companies
   - softwareTerms

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -52,3 +52,7 @@ spacebar
 touchstart
 touchend
 ultrahaptics
+
+# dialog element attributes to be submitted to cSpell
+commandfor
+closedby

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -48,7 +48,6 @@ mouseup
 multipoint
 preselection
 preselections
-sotd
 spacebar
 touchstart
 touchend

--- a/custom-words.txt
+++ b/custom-words.txt
@@ -48,6 +48,7 @@ mouseup
 multipoint
 preselection
 preselections
+sotd
 spacebar
 touchstart
 touchend

--- a/src/pages/explainer.astro
+++ b/src/pages/explainer.astro
@@ -7,7 +7,7 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
 <html>
 
 <head>
-    <meta charset='utf-8'>
+    <meta charset="utf-8">
     <title>Explainer for W3C Accessibility Guidelines (WCAG) 3.0</title>
     <ExplainerRespec />
     <script is:inline src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
@@ -18,12 +18,12 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
 </head>
 
 <body>
-    <section id='abstract'>
+    <section id="abstract">
         <p>The Explainer for WCAG 3 accompanies the draft of [[[?WCAG3]]]. It provides an overview of the history and goals of WCAG 3. This document also describes the current thinking on the structure of the guidelines and the conformance model. The guidelines, conformance model, and related work are still evolving.</p> 
         <p>Information on the current schedule is included below with a link to a more detailed timeline.</p>
         <p>See <a href="https://www.w3.org/WAI/standards-guidelines/wcag/wcag3-intro/">WCAG 3 Introduction</a> for more details about this work and links to WCAG technical and educational material.</p>
     </section>
-    <section id='sotd'>
+    <section id="sotd">
         <p>This is an updated draft of the WCAG 3 Explainer. It is informative, not normative, and is not expected to become a W3C Recommendation. It provides background on [[[?WCAG3]]].</p>
 
         <p>To comment, <a href="https://github.com/w3c/wcag3/issues/new">file an issue in the W3C wcag3 GitHub repository</a>. The Working Group requests that public comments be filed as new issues, one issue per discrete comment. It is free to create a GitHub account to file issues. If filing issues in GitHub is not feasible, email <a href="mailto:public-agwg-comments@w3.org?subject=WCAG%203.0%20public%20comment">public-agwg-comments@w3.org</a> (<a href="https://lists.w3.org/Archives/Public/public-agwg-comments/">comment archive</a>). In-progress updates to the guidelines can be viewed in the <a href="https://w3c.github.io/wcag3/guidelines/">public editors’ draft</a>.</p>

--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -219,7 +219,7 @@ import GuidelinesRespec from "@/components/respec/GuidelinesRespec.astro";
 
 				<p>The UA and AT used vary by language and region, and may be restricted in closed environments such as behind firewalls or on kiosks. As a result, it is important to understand which UA and AT support which methods and clearly state what UA and AT are assumed on conformance statements. The concept that methods must be supported by users' assistive technologies as well as the accessibility features in browsers and other user agents is referred to as "accessibility supported".</p>
 
-				<p><img src="img/conformance-model.png" alt="diagram of the conformace model showing the core and supplemental requirements with lines for bronze, silver and gold level" style="width: 100%"></p>
+				<p><img src="img/conformance-model.png" alt="diagram of the conformance model showing the core and supplemental requirements with lines for bronze, silver and gold level" style="width: 100%"></p>
 
 				<h5>Accessibility support set</h5>
 


### PR DESCRIPTION
The html-tags was hiding the previous  typo in the alt tag. 
The format of the `language` key was flagged in VSCode, just because it doesn't match the cSpell config file schema. Didn't seem to affect the running of the tool previously.