### PR TITLE
Reuse ProvisionsList in "Provisions under this guideline"

### DIFF
--- a/src/pages/informative/[groupId]/[guidelineSlug]/index.astro
+++ b/src/pages/informative/[groupId]/[guidelineSlug]/index.astro
@@ -2,7 +2,7 @@
 import type { GetStaticPaths, GetStaticPathsResult } from "astro";
 
 import KeyTerms from "@/components/informative/KeyTerms.astro";
-import ProvisionLink from "@/components/informative/ProvisionLink.astro";
+import ProvisionsList from "@/components/informative/ProvisionsList.astro";
 import InformativeLayout from "@/layouts/InformativeLayout.astro";
 import {
   formatNormativeContent,
@@ -52,13 +52,7 @@ const { html, terms } = processKeyTerms(
   <h2>Provisions under this guideline</h2>
   {
     provisions.length ? (
-      <ul>
-        {provisions.map((provision) => (
-          <li>
-            <ProvisionLink entry={provision} />
-          </li>
-        ))}
-      </ul>
+      <ProvisionsList guideline={guideline} />
     ) : (
       <div class="ednote">
         <p>


### PR DESCRIPTION
This reuses the same component that is used for listing provisions under each guideline in the top-level informative page, within the "Provisions under this guideline" section of each informative guideline page. The net effect of this is adding the provision type and status next to each name.

@netlify /informative/images-and-media/image-alternatives/#provisions-under-this-guideline