### PR TITLE
Improve aria-labels for permalinks

### DIFF
--- a/src/components/respec/GuidelinesRespec.astro
+++ b/src/components/respec/GuidelinesRespec.astro
@@ -168,6 +168,25 @@ import GuidelinesRespecDev from "./GuidelinesRespecDev.astro";
     });
   }
 
+  /**
+   * Expands permalink labels to include the entire content of each section's heading,
+   * rather than only "Permalink for Section <number/letter>".
+   * In cases where the heading still begins with a section number/letter this will
+   * still include the word "Section", but in other cases it will not,
+   * i.e. when the section number is preceded by another word (e.g. "Guideline")
+   * or is omitted entirely (e.g. for provisions).
+   */
+  function overridePermalinkLabels() {
+    document.querySelectorAll(".self-link").forEach((el) => {
+      const sectionEl = el.closest("section");
+      const headingContent = sectionEl.querySelector("h2, h3, h4, h5, h6").textContent.trim();
+      el.setAttribute(
+        "aria-label",
+        `Permalink for ${/^[A-Z0-9]\./.test(headingContent) ? "Section " : ""}${headingContent}`
+      );
+    });
+  }
+
   function removeDraftMethodLinks() {
     document.querySelectorAll(".method-link").forEach(function (node) {
       uri = node.href;
@@ -545,6 +564,9 @@ import GuidelinesRespecDev from "./GuidelinesRespecDev.astro";
       addGuidelineText,
       moveGuidelineSelfLink,
       addRequirementType,
+      overridePermalinkLabels,
+      // Status markers are added after overriding permalink labels,
+      // as they affect heading text
       addStatusMarkers,
       numberNotes,
       renumberExamples,


### PR DESCRIPTION
On a previous editors call, someone pointed out that permalinks' aria-labels all say "Permalink for Section <number>", which is particularly problematic in our case since we elected to hide section numbers for provisions.

This updates permalinks' aria-labels to include the full heading text, which results in the following behaviors:

- For headings which still begin with a section number (or letter, for appendices): "Permalink for Section <number/letter> <heading text>"
- For guidelines: "Permalink for Guideline <number> <heading text>"
- For provisions: "Permalink for <heading text>"

(I have not gone out of my way to include the provision type in the case of provisions, because it comes _after_ the heading text in the DOM order, and I'm not sure that makes the most sense here as opposed to the other cases where Section or Guideline comes first, so doing that would require some special-case code.)