### PR TITLE
overridePermalinkLabels: Skip self-links that aren't in a section

### DIFF
--- a/src/components/respec/GuidelinesRespec.astro
+++ b/src/components/respec/GuidelinesRespec.astro
@@ -179,6 +179,8 @@ import GuidelinesRespecDev from "./GuidelinesRespecDev.astro";
   function overridePermalinkLabels() {
     document.querySelectorAll(".self-link").forEach((el) => {
       const sectionEl = el.closest("section");
+      if (!sectionEl) return; // Occurs for e.g. permalinks inside dfn-panel
+
       const headingContent = sectionEl.querySelector("h2, h3, h4, h5, h6").textContent.trim();
       el.setAttribute(
         "aria-label",


### PR DESCRIPTION
I somehow overlooked that #818 caused an error, due to permalinks that exist outside of any section, e.g. those within `dfn-panel` elements. This post-processing routine only cares about permalinks within sections.