### PR TITLE
Add explicit darkmode support to account for ReSpec 37.3.3+

### DIFF
--- a/src/components/respec/GuidelinesRespecDev.astro
+++ b/src/components/respec/GuidelinesRespecDev.astro
@@ -13,7 +13,7 @@
     const respecEl = document.getElementById("respec-ui");
     const el = document.createElement("a");
     el.href = "" + newUrl;
-    el.style.background = "#fff";
+    el.style.background = "--var(bg)";
     el.style.padding = "0.25em";
     el.style.position = "fixed";
     el.style.top = "60px";

--- a/src/pages/explainer.astro
+++ b/src/pages/explainer.astro
@@ -9,6 +9,7 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
 <head>
     <meta charset='utf-8'>
     <title>Explainer for W3C Accessibility Guidelines (WCAG) 3.0</title>
+    <meta name="color-scheme" content="light dark">
     <ExplainerRespec />
     <script is:inline src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <style is:global>

--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -8,8 +8,9 @@ import GuidelinesRespec from "@/components/respec/GuidelinesRespec.astro";
 <!DOCTYPE html>
 <html lang="en-US">
 	<head>
-		<title>W3C Accessibility Guidelines (WCAG) 3.0</title>
 		<meta charset="UTF-8" />
+		<title>W3C Accessibility Guidelines (WCAG) 3.0</title>
+		<meta name="color-scheme" content="light dark">
 		<GuidelinesRespec />
 		<script is:inline src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<style is:global>

--- a/src/pages/requirements.astro
+++ b/src/pages/requirements.astro
@@ -6,8 +6,9 @@ import RequirementsRespec from "@/components/respec/RequirementsRespec.astro";
 <!DOCTYPE html>
 <html lang="en-US">
 	<head>
-		<title>Requirements for WCAG 3.0</title>
 		<meta charset="UTF-8" />
+		<title>Requirements for WCAG 3.0</title>
+		<meta name="color-scheme" content="light dark">
 		<RequirementsRespec />
 		<script is:inline src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 	</head>

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -13,4 +13,9 @@
   border-radius: 3px;
   text-transform: uppercase;
   letter-spacing: 1px;
+
+  .darkmode & {
+    background: #122f62;
+    color: #d0e1f1;
+  }
 }

--- a/src/styles/explainer.css
+++ b/src/styles/explainer.css
@@ -4,7 +4,7 @@ caption {
 :not(.head) > details {
 	padding: 1em;
 	color: color-mix(in srgb, var(--text) 75%, transparent 25%);
-	background-color: var(--toc-sidebar-bg);
+	background-color: var(--tocsidebar-bg);
 	border: medium solid #d9d9d9;
 }
 summary::after {

--- a/src/styles/explainer.css
+++ b/src/styles/explainer.css
@@ -3,9 +3,9 @@ caption {
 }
 :not(.head) > details {
 	padding: 1em;
-	color: #404040;
+	color: color-mix(in srgb, var(--text) 75%, transparent 25%);
+	background-color: var(--toc-sidebar-bg);
 	border: medium solid #d9d9d9;
-	background-color: #F3F3F3;
 }
 summary::after {
 	display: inline-block;

--- a/src/styles/explainer.css
+++ b/src/styles/explainer.css
@@ -3,9 +3,12 @@ caption {
 }
 :not(.head) > details {
 	padding: 1em;
-	color: color-mix(in srgb, var(--text) 75%, transparent 25%);
 	background-color: var(--tocsidebar-bg);
 	border: medium solid #d9d9d9;
+
+	.darkmode & {
+		border-color: #444;
+	}
 }
 summary::after {
 	display: inline-block;

--- a/src/styles/guidelines.css
+++ b/src/styles/guidelines.css
@@ -1,5 +1,5 @@
 :root {
-	--diminished-text: #404040;
+	--diminished-text: color-mix(in srgb, var(--text) 75%, transparent 25%);
 }
 
 caption {
@@ -10,7 +10,7 @@ caption {
 	padding: 1em;
 	color: var(--diminished-text);
 	border: medium solid #d9d9d9;
-	background-color: #F3F3F3;
+	background-color: var(--toc-sidebar-bg);
 	margin-block:1em;
 }
 summary::after {
@@ -213,7 +213,7 @@ section {
 	color: var(--diminished-text);
 
 	a[href] {
-		color: inherit;
+		color: var(--diminished-text);
 		text-underline-offset: 0.125em;
 
 		&, &:hover {

--- a/src/styles/guidelines.css
+++ b/src/styles/guidelines.css
@@ -11,6 +11,10 @@ caption {
 	border: medium solid #d9d9d9;
 	background-color: var(--tocsidebar-bg);
 	margin-block:1em;
+
+	.darkmode & {
+		border-color: #444;
+	}
 }
 summary::after {
 	display: inline-block;
@@ -210,6 +214,10 @@ section {
 	border-radius: 2px;
 	border: 1px solid #ccc;
 	color: var(--diminished-text);
+
+	.darkmode & {
+		border-color: #555;
+	}
 
 	a[href] {
 		color: var(--diminished-text);

--- a/src/styles/guidelines.css
+++ b/src/styles/guidelines.css
@@ -8,9 +8,8 @@ caption {
 :not(.head) > details:not(.issue) {
 	clear: both;
 	padding: 1em;
-	color: var(--diminished-text);
 	border: medium solid #d9d9d9;
-	background-color: var(--toc-sidebar-bg);
+	background-color: var(--tocsidebar-bg);
 	margin-block:1em;
 }
 summary::after {


### PR DESCRIPTION
ReSpec 37.3.3 included a surprising change which forces inclusion of dark mode support for every document it processes. The way the change was made, there doesn't seem to be any way to opt out, and moreover, I am concerned that documents that do not explicitly opt in might find themselves in an inconsistent state since they don't actually include the previously-required `meta` tag.

As such, to account for this change (which I would consider breaking, despite only the patch version bump), I have:

- Explicitly included the meta tag to indicate support for light and dark modes
  - As it turns out, without this, any document pre-processed through ReSpec 37.3.3 without this tag explicitly included now shows the theme toggle but it doesn't work at all
- Gone through our documents and updated styles to accommodate dark mode support:
  - Reference `--bg` CSS variable for "preview without early-stage entries" link when running client-side
  - Rephrase `#404040` (AKA `--diminished-text` in `guidelines.css`) using `color-mix` based on the `--text` CSS variable
  - Reuse `--tocsidebar-bg` CSS variable for details element backgrounds, as it already uses a very similar value to what we had hard-coded
  - Explicitly reference CSS variable for links inside `.doclinks`, because `inherit` was inheriting light mode's value in dark mode