### PR TITLE
Fix mispositioned status markers at the guideline level

### DIFF
--- a/src/components/respec/GuidelinesRespec.astro
+++ b/src/components/respec/GuidelinesRespec.astro
@@ -73,12 +73,14 @@ import GuidelinesRespecDev from "./GuidelinesRespecDev.astro";
     var statusKeys = Object.keys(statusLabels);
     statusKeys.forEach(function (status) {
       var headingSelector = '[data-status="' + status + '"] > .header-wrapper';
-      var headings = document.querySelectorAll(headingSelector);
-      headings.forEach(function (heading) {
+      var wrappers = document.querySelectorAll(headingSelector);
+      wrappers.forEach(function (wrapper) {
         var statusMarker = document.createElement("span");
         statusMarker.classList.add("status-marker");
         statusMarker.innerHTML = sentenceCase(status);
-        heading.firstElementChild.insertAdjacentElement("beforeend", statusMarker);
+        // Target the heading itself, not firstElementChild, since moveGuidelineSelfLink
+        // may have already relocated the self-link before the heading
+        findHeading(wrapper).insertAdjacentElement("beforeend", statusMarker);
       });
 
       var dfnSelector = '[data-status="' + status + '"] > dfn';


### PR DESCRIPTION
In #800, I introduced some markup manipulation for provision-level status markers (e.g., “Developing”). That caused a bug in the positioning for status markers at the guideline level:

<img width="963" height="419" alt="An annotated screencap showing a guideline status marker mispositioned to the left of the heading in the gutter of the document." src="https://github.com/user-attachments/assets/a14d4cdb-3b28-4dfe-8b4f-64beb3021c78" />

This PR fixes that.
