### PR TITLE
Make hardcoded color values resilient to dark mode

### DIFF
--- a/src/styles/guidelines.css
+++ b/src/styles/guidelines.css
@@ -1,5 +1,5 @@
 :root {
-	--diminished-text: #404040;
+	--diminished-text: color-mix(in srgb, var(--text) 75%, transparent);
 }
 
 caption {
@@ -8,9 +8,8 @@ caption {
 :not(.head) > details:not(.issue) {
 	clear: both;
 	padding: 1em;
-	color: var(--diminished-text);
-	border: medium solid #d9d9d9;
-	background-color: #F3F3F3;
+	border: medium solid color-mix(in srgb, var(--text) 12%, transparent);
+	background-color: color-mix(in srgb, var(--text) 5%, transparent);
 	margin-block:1em;
 }
 summary::after {
@@ -24,10 +23,15 @@ summary::after {
 	top: .25em;
 	float: right;
 }
+
+/*
+TODO: These cosmetic hover styles have been sabotaged by dark mode. Revisit.
 :not(.head) > details:focus summary::after, :not(.head) > details:hover summary::after {
-	background-color: #ffff99 ;
-	box-shadow: 0 0 1em .25em #ffff99;
+	background-color: color-mix(in srgb, yellow 40%, transparent);
+	box-shadow: 0 0 1em .25em color-mix(in srgb, yellow 40%, transparent);
 }
+*/
+
 .summary summary::after {
 	content: url(img/summary.svg);
 }
@@ -209,7 +213,7 @@ section {
 	gap: .5em;
 	padding: 5px 10px;
 	border-radius: 2px;
-	border: 1px solid #ccc;
+	border: 1px solid color-mix(in srgb, var(--text) 20%, transparent);
 	color: var(--diminished-text);
 
 	a[href] {


### PR DESCRIPTION
ReSpec’s recently-pushed dark mode has revealed some hard-coded color values in our styles that do not have sufficient contrast in dark mode.

This PR is not exhaustive, but does address some of these instances by using the CSS `color-mix()` function to derive dark mode equivalents for the hardcoded values which had assumed light mode.

I also made an editorial decision to [temporarily disable](https://github.com/w3c/wcag3/pull/829/changes#diff-2dc46f760d1c9a68261b0333efc56a2d8e536f07cfa53b2d99395847201b2fefR28-R33) the cosmetic effect that adds a yellow glow behind `summary::after` elements on hover. It seems these styles were also originally intended to trigger on focus, but a bug in the selector prevented that. In any case, the glow technique didn’t translate easily to dark mode. Because there is still a sufficiently visible outline on focus, I opted to disable these styles and add a `TODO` note to revisit them later.

Here are some deep review links:

- [Plain language summary of “Guidelines”](https://deploy-preview-829--wcag3.netlify.app/guidelines/#guidelines)
- [Images and media guidelines](https://deploy-preview-829--wcag3.netlify.app/guidelines/#images-and-media)
