### PR TITLE
Show draft badge/box using WAI styles

### DIFF
--- a/src/components/informative/DraftBanner.astro
+++ b/src/components/informative/DraftBanner.astro
@@ -1,17 +1,13 @@
 ---
-import { isDraft } from "@/lib/constants";
+import { isUnpublished } from "@/lib/constants";
 ---
 
-<section aria-label="draft preview" role="note" class="default-grid info" tabindex="0">
-  <p class="inner">
-    {
-      isDraft ? (
-        <>
-          This is an unpublished, in-progress draft. The content is incomplete and could change substantially.
-        </>
-      ) : (
-        <>This is an in-progress draft. The content is incomplete and could change substantially.</>
-      )
-    }
-  </p>
-</section>
+{
+  isUnpublished && (
+    <section aria-label="draft preview" role="note" class="default-grid info" tabindex="0">
+      <p class="inner">
+        This is an unpublished draft that might include content that is not yet approved.
+      </p>
+    </section>
+  )
+}

--- a/src/components/informative/DraftBanner.astro
+++ b/src/components/informative/DraftBanner.astro
@@ -11,3 +11,10 @@ import { isUnpublished } from "@/lib/constants";
     </section>
   )
 }
+
+<style>
+  .inner {
+    margin: 0;
+    padding: 1em 0;
+  }
+</style>

--- a/src/components/informative/DraftBanner.astro
+++ b/src/components/informative/DraftBanner.astro
@@ -2,12 +2,16 @@
 import { isDraft } from "@/lib/constants";
 ---
 
-{
-  isDraft && (
-    <section aria-label="draft preview" role="note" class="default-grid info" tabindex="0">
-      <p class="inner">
-        This is an early unpublished editor's draft; content is incomplete and subject to change.
-      </p>
-    </section>
-  )
-}
+<section aria-label="draft preview" role="note" class="default-grid info" tabindex="0">
+  <p class="inner">
+    {
+      isDraft ? (
+        <>
+          This is an early unpublished editor's draft; content is incomplete and subject to change.
+        </>
+      ) : (
+        <>This is an early working draft; content is incomplete and subject to change.</>
+      )
+    }
+  </p>
+</section>

--- a/src/components/informative/DraftBanner.astro
+++ b/src/components/informative/DraftBanner.astro
@@ -7,10 +7,10 @@ import { isDraft } from "@/lib/constants";
     {
       isDraft ? (
         <>
-          This is an early unpublished editor's draft; content is incomplete and subject to change.
+          This is an unpublished, in-progress draft. The content is incomplete and could change substantially.
         </>
       ) : (
-        <>This is an early working draft; content is incomplete and subject to change.</>
+        <>This is an in-progress draft. The content is incomplete and could change substantially.</>
       )
     }
   </p>

--- a/src/components/informative/Header.astro
+++ b/src/components/informative/Header.astro
@@ -6,7 +6,7 @@ import { informativeSlug, informativeTitle } from "@/lib/constants";
   <header class="minimal-header" id="site-header">
     <div class="minimal-header-info">
       <div class="minimal-header-title">
-        <a href={`${import.meta.env.BASE_URL}${informativeSlug}/`}>{informativeTitle}</a>
+        <a href={`${import.meta.env.BASE_URL}${informativeSlug}/`}>(Draft) {informativeTitle}</a>
       </div>
     </div>
     <div class="minimal-header-logo">

--- a/src/layouts/InformativeLayout.astro
+++ b/src/layouts/InformativeLayout.astro
@@ -24,11 +24,11 @@ const { breadcrumbSegments, entry, title, withNav = true } = Astro.props;
 <html lang="en-US">
   <head>
     <meta charset="utf-8" />
-    <title>{`${title ? `${title} - ` : ""}${informativeTitle} | WAI | W3C`}</title>
+    <title>[Draft] {`${title ? `${title} - ` : ""}${informativeTitle} | WAI | W3C`}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="https://w3.org/WAI/assets/css/style.css" />
   </head>
-  <body dir="ltr">
+  <body dir="ltr" class="doc-note doc-draft">
     <a href="#main" class="button button--skip-link">Skip to content</a>
     <DraftBanner />
     <Header />
@@ -49,6 +49,9 @@ const { breadcrumbSegments, entry, title, withNav = true } = Astro.props;
       }
       <main id="main" class="standalone-resource__main" tabindex="-1">
         <h1>{title || informativeTitle}</h1>
+        <section class="doc-note-box">
+          This is an in-progress draft. The content is incomplete and could change substantially.
+        </section>
         <slot />
       </main>
     </div>
@@ -59,6 +62,15 @@ const { breadcrumbSegments, entry, title, withNav = true } = Astro.props;
 
 <style is:global>
   @import "@/styles/common.css";
+
+  .doc-note h1::before {
+    /* Port WAI style in dir-agnostic form */
+    margin-inline-end: 8px;
+  }
+
+  .doc-note.doc-draft {
+    border-left: solid 5px var(--gold);
+  }
 
   main {
     display: block;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -2,7 +2,7 @@
 export const isDevOrPreview = !!import.meta.env.DEV || !!import.meta.env.NETLIFY;
 
 /** Indicates that the build is for dev, PR preview, or ED (not publication to WAI site). */
-export const isDraft = isDevOrPreview || !!import.meta.env.GITHUB_ACTION;
+export const isUnpublished = isDevOrPreview || !!import.meta.env.GITHUB_ACTION;
 
 export const informativeSlug = "informative";
 export const informativeTitle = "WCAG 3 Support Material";


### PR DESCRIPTION
Based on discussion with Kevin, we will probably want to show the banner at the top of informative pages even when it is initially published to the WAI site. Originally I had written the logic so the banner would be hidden in that case.

Exact message (in the "else" path) still TBD.