### PR TITLE
Fail on common directive mistakes not caught by remark-directive

### DIFF
--- a/guidelines/groups/input-operation/keyboard-interface-input/no-keyboard-traps.md
+++ b/guidelines/groups/input-operation/keyboard-interface-input/no-keyboard-traps.md
@@ -7,7 +7,7 @@ Components that can be activated or entered using the keyboard interface, can be
 
 :::except-when
 - The non-standard keyboard navigation technique is described in the :term[page]/:term[view] or earlier in the :term[process].
-::: 
+:::
 
 :::example
 * Ensuring that users can exit a modal dialog, menu, or calendar picker after entering it.

--- a/src/lib/markdown/common.ts
+++ b/src/lib/markdown/common.ts
@@ -38,6 +38,25 @@ const directivePrefixMap = {
 } as const;
 
 const checkDirectives: RemarkPlugin = () => (tree, file) => {
+  const content = "" + file.value;
+  const lines = content.split(/\r?\n/);
+  const blockDirectiveStartCount = lines.reduce(
+    (total, line) => (/^:{3,}\S+/.test(line) ? total + 1 : total),
+    0
+  );
+  const blockDirectiveEndCount = lines.reduce(
+    (total, line) => (/^:{3,}$/.test(line) ? total + 1 : total),
+    0
+  );
+  if (blockDirectiveStartCount !== blockDirectiveEndCount) file.fail(`Make sure each block directive has a matching end marker (:::)`);
+
+  const textDirectivePattern = /(\w+):(\[[^\]]+\])/.exec(content);
+  if (textDirectivePattern) {
+    file.fail(
+      `This looks like a mistyped text directive: ${textDirectivePattern[0]} → :${textDirectivePattern[1]}${textDirectivePattern[2]}`
+    );
+  }
+
   visit(tree, (node) => {
     if (
       (node.type === "containerDirective" ||
@@ -48,6 +67,14 @@ const checkDirectives: RemarkPlugin = () => (tree, file) => {
       file.fail(
         `Unrecognized ${node.type.replace(/D/, " d")} ${directivePrefixMap[node.type]}${node.name}`
       );
+    }
+
+    if (node.type === "paragraph") {
+      const firstChild = node.children[0];
+      if (firstChild.type === "text" && firstChild.value.startsWith(":::"))
+        file.fail(
+          `Invalid block directive marker (content should start on a new line): ${firstChild.value}`
+        );
     }
   });
 };


### PR DESCRIPTION
The latest instance of one of these types of mistakes finally reminded me to investigate how hard it would be to properly flag them, since `remark-directive` clearly doesn't.

This PR adds failures on 3 types of mistakes:

- Unpaired block directive markers (e.g. `:::note` without a matching `:::`)
  - Error message: `Make sure each block directive has a matching end marker (:::)`
  - This check is slightly naive, but sufficient for the time being (we might need to make it more thorough if we start heavily using nested block directives)
- Block directive markers without a newline before content
  - Error message: `Invalid block directive marker (content should start on a new line): :::ednote This includes sound effects and other non-spoken`
- Text directives with the colon on the wrong side of the directive name
  - Error message: `This looks like a mistyped text directive: term:[captions] → :term[captions]`

(This PR also includes removal of a trailing space in one instance of a closing block directive marker to make the check pass.)