### PR TITLE
Rename best practice to recommended practice everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Represents each fifth-level heading specifying an individual requirement or asse
   display a "needs additional research" editor's note
 - `tags` - Optional list of strings, referencing values in `guidelines/tags.json`
   - Make sure to surround these values in double-quotes to avoid YAML parsing errors
-- `type` - Optional string: `foundational`, `supplemental`, `assertion`, or `best practice`
+- `type` - Optional string: `foundational`, `supplemental`, `assertion`, or `recommended practice`
   - If not specified, the entry will be rendered as "Requirement"
     (with neither "Foundational" nor "Supplemental" qualification)
 

--- a/guidelines/groups/input-operation/keyboard-interface-input/bidirectional-navigation.md
+++ b/guidelines/groups/input-operation/keyboard-interface-input/bidirectional-navigation.md
@@ -6,7 +6,7 @@ type: foundational
 The keyboard interface can always move forward to the next interactive element and back to the previous interactive element.
 
 :::note
-Although keyboard navigation is required to be bidirectional, it is not required that it be symmetrical, even though this is usually best practice.
+Although keyboard navigation is required to be bidirectional, it is not required that it be symmetrical, even though this is usually recommended practice.
 :::
 
 :::example

--- a/guidelines/groups/layout/user-orientation/return-to-start-prominent.md
+++ b/guidelines/groups/layout/user-orientation/return-to-start-prominent.md
@@ -1,5 +1,5 @@
 ---
-type: best practice
+type: recommended practice
 status: developing
 ---
 

--- a/informative/README.md
+++ b/informative/README.md
@@ -21,13 +21,13 @@ As such, these files should not need to include any frontmatter.
 
 Content files under this subdirectory can also make use of the [Custom Directives available to both Guidelines and Informative Docs](../README.md#custom-directives-available-to-both-guidelines-and-informative-docs).
 
-### `act-rules/`, `best-practices/`, and `methods/` subdirectories
+### `act-rules/`, `recommended-practices/`, and `methods/` subdirectories
 
 Each of these folders defines a specific type of supplementary content,
 and follows the following structure:
 
 - `{technology}/` - Where `{technology}` is one of `documents`, `mobile`, or `web`; in practice, only `web` has been used so far
-  - `{technology}/{filename}.md` - Contains a single ACT rule / best practice / method:
+  - `{technology}/{filename}.md` - Contains a single ACT rule / recommended practice / method:
     - `{filename}` should match what you would like the URL slug for this entry to look like
     - The actual title and related provisions will be defined in frontmatter (see below)
 
@@ -35,7 +35,7 @@ and follows the following structure:
 
 The following fields are required:
 
-- `title` - Title of the ACT rule, best practice, or method
+- `title` - Title of the ACT rule, recommended practice, or method
 - `provisions` - List of slugs corresponding to applicable provisions for this entry;
   this should _only_ specify the provision slug (not group or guideline),
   e.g. `sections-labeled` rather than `layout/structure/sections-labeled`

--- a/informative/guidelines/consistency-across-views/consistency/consistent-navigation-labels.md
+++ b/informative/guidelines/consistency-across-views/consistency/consistent-navigation-labels.md
@@ -17,7 +17,7 @@ This consistency extends to the text alternatives. If icons or other non-text it
 
 If there are two components on a web page that both have the same functionality as a component on another page in a set of web pages, then all 3 must be consistent. Hence the two on the same page will be consistent.
 
-While it is desirable and best practice always to be consistent within a single web page, 3.2.4 Consistent Identification only addresses consistency within a set of web pages where something is repeated on more than one page in the set.
+While it is desirable and recommended practice always to be consistent within a single web page, 3.2.4 Consistent Identification only addresses consistency within a set of web pages where something is repeated on more than one page in the set.
 
 ## Benefits
 
@@ -39,7 +39,7 @@ While it is desirable and best practice always to be consistent within a single 
 	<dt>Example 5: Save icon button</dt>
 	<dd>A common "save" icon is used for buttons throughout a site where page save function is provided. These icons all have a consistent text alternative / accessible name</dd>
 	<dt>Example 6: Icon link and adjacent link to same destination</dt>
-	<dd>A graphical link containing an icon and a text link are next to each other, and go to the same location. The best practice would be to group them into one link as per [H2: Combining adjacent image and text links for the same resource](https://www.w3.org/WAI/WCAG22/Techniques/html/H2). However if they are visually positioned one above the other but separated in the source, this may not be possible. To meet the Success Criterion, the link text for these two links need only be consistent, not identical. But best practice is to have identical text so that when users encounter the second one, it is clear that it goes to the same place as the first.</dd>
+	<dd>A graphical link containing an icon and a text link are next to each other, and go to the same location. The recommended practice would be to group them into one link as per [H2: Combining adjacent image and text links for the same resource](https://www.w3.org/WAI/WCAG22/Techniques/html/H2). However if they are visually positioned one above the other but separated in the source, this may not be possible. To meet the Success Criterion, the link text for these two links need only be consistent, not identical. But recommended practice is to have identical text so that when users encounter the second one, it is clear that it goes to the same place as the first.</dd>
 	<dt>Example 7: Example of a Failure</dt>
 	<dd>A submit "search" button on one web page and a "find" button on another web page both have a field to enter a term and list topics in the website related to the term submitted. In this case, the buttons have the same functionality but are not labeled consistently.</dd>
 	<dt>Example 8: Failure primarily impacting assistive technology users</dt>

--- a/informative/guidelines/input-operation/keyboard-interface-input/bidirectional-navigation.md
+++ b/informative/guidelines/input-operation/keyboard-interface-input/bidirectional-navigation.md
@@ -2,7 +2,7 @@
 
 - Use standard HTML to create interactive elements.
 
-## Best Practices
+## Recommended Practices
 
 - Avoid modifying the tab order to be in only one direction.
 

--- a/informative/guidelines/input-operation/keyboard-interface-input/focus-placed.md
+++ b/informative/guidelines/input-operation/keyboard-interface-input/focus-placed.md
@@ -2,7 +2,7 @@
 
 - When removing interactive elements such as filters, dialogs, or popups that currently contain focus, actively place the focus back on the element that led to that element, the previous element within the focus order, or another meaningful location.
 
-## Best Practices
+## Recommended Practices
 
 - Conduct usability testing with screen reader users to evaluate the focus movement.
 

--- a/informative/guidelines/input-operation/physical-or-cognitive-effort-when-using-keyboard/no-repetitive-adjacent-interactive-elements.md
+++ b/informative/guidelines/input-operation/physical-or-cognitive-effort-when-using-keyboard/no-repetitive-adjacent-interactive-elements.md
@@ -3,7 +3,7 @@
 - When repetitive interactive elements are used, remove them from the focus and reading order.
 - Use a single link instead of multiple links to the same destination.
 
-## Best Practices
+## Recommended Practices
 
 - Combine repetitive links into a single interactive element.
 

--- a/informative/guidelines/interactive-components/control-information/input-constraints-used.md
+++ b/informative/guidelines/interactive-components/control-information/input-constraints-used.md
@@ -2,7 +2,7 @@
 
 - HTML: To programmatically indicate, use the `pattern` attribute or write the information in a label; to visually indicate, add the requirements to the page near the input.
 
-## Best Practices
+## Recommended Practices
 
 - The constraints remain persistent.
 

--- a/informative/guidelines/interactive-components/control-information/interactive-element-names-available.md
+++ b/informative/guidelines/interactive-components/control-information/interactive-element-names-available.md
@@ -2,7 +2,7 @@
 
 - Provide unique, descriptive text or image (icon) for each interactive element.
 
-## Best Practices
+## Recommended Practices
 
 - To ensure clarity, pair an icon with a persistent visible text label, or only use a persistent visible text label.
 - When an icon is the only visual label, provide a tooltip (hover label) with the text description.

--- a/informative/guidelines/interactive-components/control-information/interactive-elements-distinguishable.md
+++ b/informative/guidelines/interactive-components/control-information/interactive-elements-distinguishable.md
@@ -2,7 +2,7 @@
 
 - Add visual indicators, such as shading, border, drop-down arrow, or placement, to interactive elements.
 
-## Best Practices
+## Recommended Practices
 
 - Document interactive indicators and designs in a style guide.
 

--- a/informative/guidelines/interactive-components/control-information/label-included-in-programmatic-name.md
+++ b/informative/guidelines/interactive-components/control-information/label-included-in-programmatic-name.md
@@ -2,7 +2,7 @@
 
 - Code the same name as you display.
 
-## Best Practices
+## Recommended Practices
 
 - Use unique names and keep the programmatic and visual names the same.
 

--- a/informative/guidelines/interactive-components/expected-behavior/consistent-control-location.md
+++ b/informative/guidelines/interactive-components/expected-behavior/consistent-control-location.md
@@ -3,7 +3,7 @@
 - Establish a design system with documented rules for consistent placement of common interactive components (for example, navigation menus, search bars, and action buttons).
 - Reuse the same components across pages/views instead of recreating them.
 
-## Best Practices
+## Recommended Practices
 
 - If a visual position must change, document why and consider providing cues (for example, animations and labels) to reduce confusion.
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -71,7 +71,9 @@ export const collections = {
       needsAdditionalResearch: z.boolean().optional(),
       status: statusSchema.default("exploratory"),
       title: z.string().optional(),
-      type: z.enum(["foundational", "supplemental", "assertion", "best practice"]).optional(),
+      type: z
+        .enum(["foundational", "supplemental", "assertion", "recommended practice"])
+        .optional(),
     }),
   }),
   tags: defineCollection({
@@ -111,8 +113,8 @@ export const collections = {
     schema: relatedSchema,
   }),
 
-  bestPractices: defineCollection({
-    loader: glob({ pattern: "*/*.md", base: "./informative/best-practices" }),
+  recommendedPractices: defineCollection({
+    loader: glob({ pattern: "*/*.md", base: "./informative/recommended-practices" }),
     schema: relatedSchema,
   }),
 

--- a/src/layouts/InformativeRelatedIndexLayout.astro
+++ b/src/layouts/InformativeRelatedIndexLayout.astro
@@ -1,7 +1,7 @@
 ---
 /**
  * @file Layout used for index pages for informative materials related to provisions,
- * e.g. ACT Rules, Best Practices, Methods
+ * e.g. ACT Rules, Recommended Practices, Methods
  */
 
 import { getCollection } from "astro:content";

--- a/src/layouts/InformativeRelatedLayout.astro
+++ b/src/layouts/InformativeRelatedLayout.astro
@@ -1,7 +1,7 @@
 ---
 /**
  * @file Layout used for informative materials related to provisions,
- * e.g. ACT Rules, Best Practices, Methods
+ * e.g. ACT Rules, Recommended Practices, Methods
  */
 
 import type { CollectionEntry } from "astro:content";

--- a/src/lib/informative.ts
+++ b/src/lib/informative.ts
@@ -217,9 +217,9 @@ export const informativeRelatedTypes = {
     slug: "act-rules",
     title: "ACT Rules",
   },
-  bestPractices: {
-    slug: "best-practices",
-    title: "Best Practices",
+  recommendedPractices: {
+    slug: "recommended-practices",
+    title: "Recommended Practices",
   },
   methods: {
     slug: "methods",
@@ -261,7 +261,7 @@ export const generateInformativeRelatedGetStaticPaths =
 
 /**
  * Object hash mapping provision slugs to arrays of IDs for each informative relation type
- * (e.g. actRules, bestPractices, methods).
+ * (e.g. actRules, recommendedPractices, methods).
  * Used to reverse-map each provision to the other types of related informative entries,
  * whereas those related entries are where the mappings are defined in frontmatter.
  */

--- a/src/pages/dev/rename/[collection].astro
+++ b/src/pages/dev/rename/[collection].astro
@@ -48,7 +48,7 @@ if (!options) return Astro.redirect("/dev/"); // This will only happen on invali
               Draft
             </li>
             <li>
-              Slug references from other informative docs, e.g. ACT rules, best practices, and
+              Slug references from other informative docs, e.g. ACT rules, recommended practices, and
               methods
             </li>
           </>

--- a/src/pages/explainer.astro
+++ b/src/pages/explainer.astro
@@ -180,7 +180,7 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
                             </li>
                         </ul>
                     </li>
-                    <li>Best practices - informative
+                    <li>Recommended practices - informative
                         <ul>
                             <li>How to Documents - informative
                             </li>
@@ -312,12 +312,12 @@ import ExplainerRespec from "@/components/respec/ExplainerRespec.astro";
                     </ul>
                 </div>
  
-        <h3>Best practices</h3>
-        <p>Best practices reduce or eliminate barriers that people with disabilities experience. They provide important guidance that often saves time and improve accessibility, but they cannot be requirements because:
+        <h3>Recommended practices</h3>
+        <p>Recommended practices reduce or eliminate barriers that people with disabilities experience. They provide important guidance that often saves time and improve accessibility, but they cannot be requirements because:
             <ul><li>they may not be objectively testable, or</li> 
                 <li>the situations to which they apply may not be clearly defined and may require a judgement call.</li>
             </ul></p>
-                <p>Best practices are informative and do not affect conformance.</p>
+                <p>Recommended practices are informative and do not affect conformance.</p>
         </section>
 
         <section id="testing" data-status="exploratory">

--- a/src/pages/informative/best-practices/[technology]/[slug].astro
+++ b/src/pages/informative/best-practices/[technology]/[slug].astro
@@ -3,11 +3,11 @@ import InformativeRelatedLayout from "@/layouts/InformativeRelatedLayout.astro";
 import { generateInformativeRelatedGetStaticPaths } from "@/lib/informative";
 import { getEntry } from "astro:content";
 
-export const getStaticPaths = generateInformativeRelatedGetStaticPaths("bestPractices");
+export const getStaticPaths = generateInformativeRelatedGetStaticPaths("recommendedPractices");
 
 const id = `${Astro.params.technology}/${Astro.params.slug}`;
-const entry = await getEntry("bestPractices", id);
-if (!entry) throw new Error(`Unresolvable Best Practice ID: ${id}`);
+const entry = await getEntry("recommendedPractices", id);
+if (!entry) throw new Error(`Unresolvable Recommended Practice ID: ${id}`);
 ---
 
 <InformativeRelatedLayout entry={entry} />

--- a/src/pages/informative/best-practices/[technology]/index.astro
+++ b/src/pages/informative/best-practices/[technology]/index.astro
@@ -7,7 +7,7 @@ import { technologies } from "@/lib/informative";
 export const getStaticPaths: GetStaticPaths = () =>
   technologies.map((technology) => ({ params: { technology } }));
 
-const path = `${informativeSlug}/best-practices/#${Astro.params.technology}`;
+const path = `${informativeSlug}/recommended-practices/#${Astro.params.technology}`;
 // path is always truthy, but this works around https://github.com/withastro/language-tools/issues/476
 if (path) return Astro.redirect(`${import.meta.env.BASE_URL}${path}`);
 ---

--- a/src/pages/informative/best-practices/index.astro
+++ b/src/pages/informative/best-practices/index.astro
@@ -2,4 +2,4 @@
 import InformativeRelatedIndexLayout from "@/layouts/InformativeRelatedIndexLayout.astro";
 ---
 
-<InformativeRelatedIndexLayout collectionName="bestPractices" />
+<InformativeRelatedIndexLayout collectionName="recommendedPractices" />


### PR DESCRIPTION
This follows up on a change adopted in #834 (particularly https://github.com/w3c/wcag3/pull/834#discussion_r3875944371), by rephrasing "best practice" as "recommended practice" everywhere else it is used. (This includes build system updates.)