### PR TITLE
Display status marker on informative provision page

### DIFF
--- a/src/lib/informative.ts
+++ b/src/lib/informative.ts
@@ -1,10 +1,5 @@
 import type { GetStaticPaths } from "astro";
-import {
-  getCollection,
-  getEntry,
-  type CollectionEntry,
-  type CollectionKey,
-} from "astro:content";
+import { getCollection, getEntry, type CollectionEntry, type CollectionKey } from "astro:content";
 import { load } from "cheerio";
 import noop from "lodash/noop";
 import sortBy from "lodash/sortBy";
@@ -145,8 +140,9 @@ export function incorporateNormativeContent(entry: InformativeGuideline | Inform
     return `<h2>Guideline</h2><div class="normative">${$normative.html()}</div>${entry.rendered.html}`;
 
   const $ = load(
-    `<h2>${computeProvisionTypeLabel(entry.normativeEntry)}</h2>` +
-      `<div class="normative">${$normative.html()}</div>${entry.rendered.html}`,
+    `<h2>${computeProvisionTypeLabel(entry.normativeEntry)} <span class="status-marker">${
+      entry.normativeEntry.data.status
+    }</span></h2><div class="normative">${$normative.html()}</div>${entry.rendered.html}`,
     null,
     false
   );


### PR DESCRIPTION
This adds the status marker in the heading above the quoted normative text.

Note: This only covers the provision level under informative, not the guideline level. We technically have 2 guidelines with the "developing" status marker, but I'm not sure it's useful at that level anymore, and I'd be more inclined to remove the status marker at that level overall.