### PR TITLE
Shorten issue labels that would end up over 50-char limit by default

### DIFF
--- a/guidelines/groups/images-and-media/audio-descriptions/non-verbal-cues-identified-in-audio-descriptions.md
+++ b/guidelines/groups/images-and-media/audio-descriptions/non-verbal-cues-identified-in-audio-descriptions.md
@@ -3,6 +3,8 @@ needsAdditionalResearch: true
 status: exploratory
 type: foundational
 title: Non-verbal cues identified in audio descriptions
+# Shorten issue label to keep under 50 character limit
+issueLabel: Non-verbal cues identified in audio desc
 ---
 
 Nonverbal cues needed to understand the media are explained in :term[audio descriptions].

--- a/guidelines/groups/images-and-media/audio-descriptions/speaker-language-identified-in-audio-descriptions.md
+++ b/guidelines/groups/images-and-media/audio-descriptions/speaker-language-identified-in-audio-descriptions.md
@@ -1,6 +1,8 @@
 ---
 type: supplemental
 status: developing
+# Shorten issue label to keep under 50 character limit
+issueLabel: Speaker language identified in audio desc
 ---
 
 When more than one language is spoken in :term[audio] :term[content], the language spoken by each speaker is identified in all :term[audio descriptions].

--- a/guidelines/groups/images-and-media/audio-descriptions/visual-information-identified-in-audio-descriptions.md
+++ b/guidelines/groups/images-and-media/audio-descriptions/visual-information-identified-in-audio-descriptions.md
@@ -1,6 +1,8 @@
 ---
 type: foundational
 status: developing
+# Shorten issue label to keep under 50 character limit
+issueLabel: Visual information identified in audio desc
 ---
 
 Visual information needed to understand the media is described in :term[audio descriptions].


### PR DESCRIPTION
When migrating issue labels, I found out that three of the auto-generated labels based on new provision names will exceed the length allowed by GitHub (50 characters), so I had to shorten them.

This adds `issueLabel` fields to the 3 affected issues. I tested that their issue links work against the now-renamed labels in GitHub.

If needed, here is a patch that can be applied to the existing build output from the main branch:

```diff
diff -ru dist/client/guidelines/index.html dist-after/client/guidelines/index.html
--- dist/client/guidelines/index.html	2026-09-09 20:37:06.533179062 -0400
+++ dist-after/client/guidelines/index.html	2026-09-09 20:35:38.930298292 -0400
@@ -985,13 +985,13 @@
 <li>Identity is identifiable within the context of use.</li>
 </ul>
 <aside class="example"><p>Initially using “Maya Angelou” within the context of a story regarding poetry and then using “Angelou”.</p></aside> <aside class="doclinks"> <a href="https://github.com/w3c/wcag3/issues?q=state%3Aopen%20label%3A%22P%20-%20Speakers%20identified%20in%20audio%20descriptions%22"> <svg aria-hidden="true" class="i-issue"> <use xlink:href="img/icons.svg#i-issue"></use> </svg><span>Speakers identified in audio descriptions issues</span> </a> </aside> </div></section><section class="requirement" data-status="developing" data-requirement-type-label="Supplemental requirement"><h5> <a href="/informative/images-and-media/audio-descriptions/speaker-language-identified-in-audio-descriptions/">Speaker language identified in audio descriptions</a> </h5> <div class="provision-body"> <p>When more than one language is spoken in <a>audio</a> <a>content</a>, the language spoken by each speaker is identified in all <a>audio descriptions</a>.</p>
-<p><b>Except when</b> words are used incidentally.</p> <aside class="doclinks"> <a href="https://github.com/w3c/wcag3/issues?q=state%3Aopen%20label%3A%22P%20-%20Speaker%20language%20identified%20in%20audio%20descriptions%22"> <svg aria-hidden="true" class="i-issue"> <use xlink:href="img/icons.svg#i-issue"></use> </svg><span>Speaker language identified in audio descriptions issues</span> </a> </aside> </div></section><section class="requirement" data-status="developing" data-requirement-type-label="Core requirement"><h5> <a href="/informative/images-and-media/audio-descriptions/sounds-identified-in-audio-descriptions/">Sounds identified in audio descriptions</a> </h5> <div class="provision-body"> <p>Sounds needed to understand the media are identified or described in <a>captions</a> and <a>transcripts</a>.</p>
+<p><b>Except when</b> words are used incidentally.</p> <aside class="doclinks"> <a href="https://github.com/w3c/wcag3/issues?q=state%3Aopen%20label%3A%22P%20-%20Speaker%20language%20identified%20in%20audio%20desc%22"> <svg aria-hidden="true" class="i-issue"> <use xlink:href="img/icons.svg#i-issue"></use> </svg><span>Speaker language identified in audio descriptions issues</span> </a> </aside> </div></section><section class="requirement" data-status="developing" data-requirement-type-label="Core requirement"><h5> <a href="/informative/images-and-media/audio-descriptions/sounds-identified-in-audio-descriptions/">Sounds identified in audio descriptions</a> </h5> <div class="provision-body"> <p>Sounds needed to understand the media are identified or described in <a>captions</a> and <a>transcripts</a>.</p>
 <div class="ednote"><p>This includes sound effects and other non-spoken <a>audio</a> <a>content</a>.</p></div>
 <p><b>Applies when</b> there is sound.</p>
 <p><b>Except when</b> the video is <a>decorative</a>.</p> <aside class="doclinks"> <a href="https://github.com/w3c/wcag3/issues?q=state%3Aopen%20label%3A%22P%20-%20Sounds%20identified%20in%20audio%20descriptions%22"> <svg aria-hidden="true" class="i-issue"> <use xlink:href="img/icons.svg#i-issue"></use> </svg><span>Sounds identified in audio descriptions issues</span> </a> </aside> </div></section><section class="requirement" data-status="developing" data-requirement-type-label="Core requirement"><h5> <a href="/informative/images-and-media/audio-descriptions/visual-information-identified-in-audio-descriptions/">Visual information identified in audio descriptions</a> </h5> <div class="provision-body"> <p>Visual information needed to understand the media is described in <a>audio descriptions</a>.</p>
 <div class="ednote"><ul>
 <li>This includes actions, charts or <a>informative</a> visuals, scene changes, and on-screen <a>text</a>,</li>
-</ul></div> <aside class="doclinks"> <a href="https://github.com/w3c/wcag3/issues?q=state%3Aopen%20label%3A%22P%20-%20Visual%20information%20identified%20in%20audio%20descriptions%22"> <svg aria-hidden="true" class="i-issue"> <use xlink:href="img/icons.svg#i-issue"></use> </svg><span>Visual information identified in audio descriptions issues</span> </a> </aside> </div></section><section class="requirement" data-status="exploratory" data-requirement-type-label="Core requirement"><h5> <a href="/informative/images-and-media/audio-descriptions/non-verbal-cues-identified-in-audio-descriptions/">Non-verbal cues identified in audio descriptions</a> </h5> <div class="provision-body"> <p>Nonverbal cues needed to understand the media are explained in <a>audio descriptions</a>.</p> <aside class="doclinks"> <a href="https://github.com/w3c/wcag3/issues?q=state%3Aopen%20label%3A%22P%20-%20Non-verbal%20cues%20identified%20in%20audio%20descriptions%22"> <svg aria-hidden="true" class="i-issue"> <use xlink:href="img/icons.svg#i-issue"></use> </svg><span>Non-verbal cues identified in audio descriptions issues</span> </a> </aside> </div></section><section class="requirement" data-status="developing" data-requirement-type-label="Assertion"><h5> <a href="/informative/images-and-media/audio-descriptions/audio-descriptions-style-guide/">Audio descriptions style guide</a> </h5> <div class="provision-body"> <p>[Title, role, or organization] asserts that:</p>
+</ul></div> <aside class="doclinks"> <a href="https://github.com/w3c/wcag3/issues?q=state%3Aopen%20label%3A%22P%20-%20Visual%20information%20identified%20in%20audio%20desc%22"> <svg aria-hidden="true" class="i-issue"> <use xlink:href="img/icons.svg#i-issue"></use> </svg><span>Visual information identified in audio descriptions issues</span> </a> </aside> </div></section><section class="requirement" data-status="exploratory" data-requirement-type-label="Core requirement"><h5> <a href="/informative/images-and-media/audio-descriptions/non-verbal-cues-identified-in-audio-descriptions/">Non-verbal cues identified in audio descriptions</a> </h5> <div class="provision-body"> <p>Nonverbal cues needed to understand the media are explained in <a>audio descriptions</a>.</p> <aside class="doclinks"> <a href="https://github.com/w3c/wcag3/issues?q=state%3Aopen%20label%3A%22P%20-%20Non-verbal%20cues%20identified%20in%20audio%20desc%22"> <svg aria-hidden="true" class="i-issue"> <use xlink:href="img/icons.svg#i-issue"></use> </svg><span>Non-verbal cues identified in audio descriptions issues</span> </a> </aside> </div></section><section class="requirement" data-status="developing" data-requirement-type-label="Assertion"><h5> <a href="/informative/images-and-media/audio-descriptions/audio-descriptions-style-guide/">Audio descriptions style guide</a> </h5> <div class="provision-body"> <p>[Title, role, or organization] asserts that:</p>
 <ul>
 <li>Our organization has a style guide that includes guidance on <a>audio descriptions</a> and a policy and/or processes that the style guide must be followed.</li>
 </ul>
```

Note there are two -/+ pairs; for some reason GitHub doesn't seem to be consistently highlighting the second pair. Within the 2 changed lines there are a total of 3 changes from `audio%20descriptions` to `audio%20desc`.