### PR TITLE
Add link to published version from unpublished draft banner

### DIFF
--- a/src/components/informative/DraftBanner.astro
+++ b/src/components/informative/DraftBanner.astro
@@ -7,6 +7,7 @@ import { isUnpublished } from "@/lib/constants";
     <section aria-label="draft preview" role="note" class="default-grid info" tabindex="0">
       <p class="inner">
         This is an unpublished draft that might include content that is not yet approved.
+        <a href={`https://www.w3.org/WAI/WCAG3${Astro.url.pathname}`}>View the published version</a>
       </p>
     </section>
   )


### PR DESCRIPTION
This adds a link at the end of the unpublished draft banner that appears at the top of informative pages in PR previews and w3c.github.io. For each page, it maps directly to the corresponding page under w3.org/WAI/WCAG3/informative.

This is equivalent to the same feature on the banners for WCAG 2 informative materials ([example](https://w3c.github.io/wcag/understanding/)).

@netlify /informative/