### PR TITLE
Remove dependency on conformance claims from content conformance requirements

### DIFF
--- a/src/pages/guidelines/index.astro
+++ b/src/pages/guidelines/index.astro
@@ -208,7 +208,7 @@ import GuidelinesRespec from "@/components/respec/GuidelinesRespec.astro";
 					<p>This update to WCAG 3 moves the concept of leveling from conformance to reporting. To keep this clear, we refer to "reporting tiers" to distinguish them from previous "conformance levels". Approaches to reporting progress towards conformance and achievements beyond conformance are explored in Section 4.</p>
 				</div>
 
-				<p>For a specified <a>conformance scope</a> to conform to WCAG 3, all core requirements MUST be satisfied.</p>
+				<p>For <a>content</a> to conform to WCAG 3, the content MUST satisfy all core requirements.</p>
 
 				<h4>Accessibility supported</h4>
 


### PR DESCRIPTION
Resolves #862 by revising the conformance requirements statement to replace "conformance scope" with "content".

[Preview proposed conformance requirements section](https://deploy-preview-861--wcag3.netlify.app/guidelines/#conformance-requirements)